### PR TITLE
macOS: add AeroSpace tiling + workspace hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,34 @@
 # scripts-prompts-config
 
-A comprehensive configuration management system for development environments, supporting both Linux and macOS. This repository contains backup/restore scripts, shell configurations, development tools setup, and AI prompts for maintaining consistent development environments.
+A comprehensive configuration management system for development environments, supporting Linux and macOS. This repository contains backup/restore scripts, shell configurations, development tools setup, and AI prompts for maintaining consistent development environments.
+
+## Current Platform Focus
+
+- Primary: `osx/` and `linux-omarchy/`
+- Deprecated: `linux-popos/` (kept for historical reference; avoid adding new configs there)
 
 ## Quick Start
 
-### Linux Setup on New System
+### macOS Setup
 
 ```bash
 # Clone the repository
 git clone https://github.com/yourusername/scripts-prompts-config.git
-cd scripts-prompts-config/linux-popos
+cd scripts-prompts-config
 
-# Restore all configurations
-./restore-configs.sh
+# Apply backed-up macOS configs
+cp osx/config/.tmux.conf ~/.tmux.conf
+mkdir -p ~/.config/ghostty
+cp osx/config/.config/ghostty/config ~/.config/ghostty/config
 
-# Configure your API keys
-cp linux-popos/config/.shell_secrets.template ~/.shell_secrets
-nano ~/.shell_secrets  # Add your actual API keys
-chmod 600 ~/.shell_secrets
-
-# Apply configurations
-source ~/.bashrc  # For bash
-source ~/.zshrc   # For zsh
+# Reload tmux config
+tmux source-file ~/.tmux.conf
 ```
+
+### Legacy Pop!_OS Scripts (Deprecated)
+
+The `linux-popos/` directory remains available, but is deprecated for ongoing updates.
+Prefer `osx/` and `linux-omarchy/` for new changes.
 
 ### Backup Current Configurations
 
@@ -69,7 +75,7 @@ scripts-prompts-config/
 ├── CLAUDE.md                   # AI assistant instructions
 ├── README.md                   # This file
 ├── TODO.md                     # Development tasks
-├── linux-popos/
+├── linux-popos/             # Deprecated (legacy Pop!_OS/Ubuntu)
 │   ├── backup-configs.sh      # Backup script (Pop!_OS/Ubuntu)
 │   ├── restore-configs.sh     # Restore script (Pop!_OS/Ubuntu)
 │   ├── config/                # Configuration files (local backups)
@@ -253,7 +259,7 @@ Install the commit-msg hook from `universal/git-hooks/` (see `universal/git-hook
 
 ## Platform-Specific Documentation
 
-- **Linux (Pop!_OS/Ubuntu)**: See [linux-popos/config/README.md](linux-popos/config/README.md) for detailed Linux configuration information
+- **Linux (Pop!_OS/Ubuntu, deprecated)**: See [linux-popos/config/README.md](linux-popos/config/README.md) (legacy)
 - **Linux (Omarchy/Arch)**: See [linux-omarchy/REPLICATION-GUIDE.md](linux-omarchy/REPLICATION-GUIDE.md) for Omarchy setup details
 - **macOS**: Utility scripts available in `osx/scripts/`
 

--- a/linux-popos/README.md
+++ b/linux-popos/README.md
@@ -1,0 +1,9 @@
+# linux-popos (Deprecated)
+
+This directory is deprecated and kept only for legacy Pop!_OS/Ubuntu setups.
+
+Use these directories for active work:
+- `osx/`
+- `linux-omarchy/`
+
+Please do not add new configs, scripts, or prompts under `linux-popos/` unless explicitly required for legacy migration.

--- a/osx/README.md
+++ b/osx/README.md
@@ -184,6 +184,30 @@ Includes:
 
 ---
 
+## 7. AeroSpace (tiling + workspaces)
+
+AeroSpace is an i3-like tiling window manager for macOS.
+
+Install:
+```bash
+brew install --cask nikitabobko/tap/aerospace
+```
+
+Copy the Omarchy-style config (Cmd+1..9 focus workspace, Cmd+Shift+1..9 move window and follow):
+```bash
+cp osx/config/.aerospace.toml ~/.aerospace.toml
+```
+
+Then launch `AeroSpace.app` and grant it Accessibility permissions:
+- System Settings -> Privacy & Security -> Accessibility -> enable `AeroSpace`
+
+Reload config after edits:
+```bash
+aerospace reload-config
+```
+
+---
+
 ## Summary Checklist
 
 - [ ] Install terminal tools (Homebrew list above)
@@ -194,3 +218,4 @@ Includes:
 - [ ] Install and configure `skhd`, enable Accessibility, start service
 - [ ] Copy Ghostty config and keybindings
 - [ ] Copy tmux config and reload tmux
+- [ ] Install AeroSpace + copy `~/.aerospace.toml` and enable Accessibility

--- a/osx/README.md
+++ b/osx/README.md
@@ -164,6 +164,26 @@ Keybindings included:
 
 ---
 
+## 6. Tmux (Omarchy-style on macOS)
+
+Backed up tmux config lives at:
+- `osx/config/.tmux.conf`
+
+Copy to your local machine:
+```bash
+cp osx/config/.tmux.conf ~/.tmux.conf
+tmux source-file ~/.tmux.conf
+```
+
+Includes:
+- `Ctrl+Space` prefix (`C-b` unbound)
+- Omarchy-style statusline and pane colors
+- Vim pane movement/resizing + mouse support
+- Ghostty truecolor compatibility (`xterm-ghostty:RGB`)
+- TPM plugins: sensible, resurrect, continuum
+
+---
+
 ## Summary Checklist
 
 - [ ] Install terminal tools (Homebrew list above)
@@ -173,3 +193,4 @@ Keybindings included:
 - [ ] Create `~/.config/starship.toml`
 - [ ] Install and configure `skhd`, enable Accessibility, start service
 - [ ] Copy Ghostty config and keybindings
+- [ ] Copy tmux config and reload tmux

--- a/osx/config/.aerospace.toml
+++ b/osx/config/.aerospace.toml
@@ -1,0 +1,116 @@
+# Place a copy of this config to ~/.aerospace.toml
+#
+# This is an Omarchy-inspired setup:
+# - cmd+1..9: focus workspace
+# - cmd+shift+1..9: move focused window to workspace AND follow it
+#
+# AeroSpace default config is located at:
+# /Applications/AeroSpace.app/Contents/Resources/default-config.toml
+
+config-version = 2
+
+# Start AeroSpace at login
+start-at-login = true
+
+after-startup-command = []
+
+# Normalizations. See: https://nikitabobko.github.io/AeroSpace/guide#normalization
+enable-normalization-flatten-containers = true
+enable-normalization-opposite-orientation-for-nested-containers = true
+
+# Layout defaults. See: https://nikitabobko.github.io/AeroSpace/guide#layouts
+accordion-padding = 30
+default-root-container-layout = 'tiles'
+default-root-container-orientation = 'auto'
+
+# Keep workspaces alive even when empty (matches the numbered workspace workflow)
+persistent-workspaces = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+
+[key-mapping]
+    preset = 'qwerty'
+
+[gaps]
+    inner.horizontal = 8
+    inner.vertical = 8
+    outer.left = 8
+    outer.bottom = 8
+    outer.top = 8
+    outer.right = 8
+
+[mode.main.binding]
+    # Layout toggles (defaults)
+    alt-slash = 'layout tiles horizontal vertical'
+    alt-comma = 'layout accordion horizontal vertical'
+
+    # Focus (defaults)
+    alt-h = 'focus left'
+    alt-j = 'focus down'
+    alt-k = 'focus up'
+    alt-l = 'focus right'
+
+    # Move (defaults)
+    alt-shift-h = 'move left'
+    alt-shift-j = 'move down'
+    alt-shift-k = 'move up'
+    alt-shift-l = 'move right'
+
+    # Resize (defaults)
+    alt-minus = 'resize smart -50'
+    alt-equal = 'resize smart +50'
+
+    # Workspaces (Omarchy-style on macOS)
+    cmd-1 = 'workspace 1'
+    cmd-2 = 'workspace 2'
+    cmd-3 = 'workspace 3'
+    cmd-4 = 'workspace 4'
+    cmd-5 = 'workspace 5'
+    cmd-6 = 'workspace 6'
+    cmd-7 = 'workspace 7'
+    cmd-8 = 'workspace 8'
+    cmd-9 = 'workspace 9'
+
+    cmd-shift-1 = 'move-node-to-workspace --focus-follows-window 1'
+    cmd-shift-2 = 'move-node-to-workspace --focus-follows-window 2'
+    cmd-shift-3 = 'move-node-to-workspace --focus-follows-window 3'
+    cmd-shift-4 = 'move-node-to-workspace --focus-follows-window 4'
+    cmd-shift-5 = 'move-node-to-workspace --focus-follows-window 5'
+    cmd-shift-6 = 'move-node-to-workspace --focus-follows-window 6'
+    cmd-shift-7 = 'move-node-to-workspace --focus-follows-window 7'
+    cmd-shift-8 = 'move-node-to-workspace --focus-follows-window 8'
+    cmd-shift-9 = 'move-node-to-workspace --focus-follows-window 9'
+
+    # Backup bindings (in case cmd+1..9 is consumed by an app, e.g. browser tab switching)
+    alt-1 = 'workspace 1'
+    alt-2 = 'workspace 2'
+    alt-3 = 'workspace 3'
+    alt-4 = 'workspace 4'
+    alt-5 = 'workspace 5'
+    alt-6 = 'workspace 6'
+    alt-7 = 'workspace 7'
+    alt-8 = 'workspace 8'
+    alt-9 = 'workspace 9'
+
+    alt-shift-1 = 'move-node-to-workspace 1'
+    alt-shift-2 = 'move-node-to-workspace 2'
+    alt-shift-3 = 'move-node-to-workspace 3'
+    alt-shift-4 = 'move-node-to-workspace 4'
+    alt-shift-5 = 'move-node-to-workspace 5'
+    alt-shift-6 = 'move-node-to-workspace 6'
+    alt-shift-7 = 'move-node-to-workspace 7'
+    alt-shift-8 = 'move-node-to-workspace 8'
+    alt-shift-9 = 'move-node-to-workspace 9'
+
+    # Service mode (defaults)
+    alt-shift-semicolon = 'mode service'
+
+[mode.service.binding]
+    esc = ['reload-config', 'mode main']
+    r = ['flatten-workspace-tree', 'mode main'] # reset layout
+    f = ['layout floating tiling', 'mode main'] # Toggle between floating and tiling layout
+    backspace = ['close-all-windows-but-current', 'mode main']
+
+    alt-shift-h = ['join-with left', 'mode main']
+    alt-shift-j = ['join-with down', 'mode main']
+    alt-shift-k = ['join-with up', 'mode main']
+    alt-shift-l = ['join-with right', 'mode main']
+

--- a/osx/config/.tmux.conf
+++ b/osx/config/.tmux.conf
@@ -1,0 +1,113 @@
+# =============================================================================
+# tmux configuration - Omarchy style
+# Prefix: Ctrl+Space
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Prefix key
+# -----------------------------------------------------------------------------
+unbind C-b
+set -g prefix C-Space
+bind C-Space send-prefix
+
+# -----------------------------------------------------------------------------
+# General settings
+# -----------------------------------------------------------------------------
+set -g default-terminal "tmux-256color"
+set -ag terminal-overrides ",xterm-ghostty:RGB"
+# Keep truecolor for common xterm-style clients too.
+set -ag terminal-overrides ",xterm-256color:RGB"
+set -g history-limit 50000
+set -g display-time 4000
+set -g status-interval 5
+set -g focus-events on
+set -g escape-time 0
+set -g base-index 1
+setw -g pane-base-index 1
+set -g renumber-windows on
+
+# Mouse support
+set -g mouse on
+
+# -----------------------------------------------------------------------------
+# Keybindings
+# -----------------------------------------------------------------------------
+# Reload config
+bind r source-file ~/.tmux.conf \; display "Config reloaded!"
+
+# Split panes using | and -
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+unbind '"'
+unbind %
+
+# New window in current path
+bind c new-window -c "#{pane_current_path}"
+
+# Vim-style pane navigation
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+# Vim-style pane resizing
+bind -r H resize-pane -L 5
+bind -r J resize-pane -D 5
+bind -r K resize-pane -U 5
+bind -r L resize-pane -R 5
+
+# Alt+arrow pane switching (no prefix needed)
+bind -n M-Left select-pane -L
+bind -n M-Right select-pane -R
+bind -n M-Up select-pane -U
+bind -n M-Down select-pane -D
+
+# Shift+arrow window switching (no prefix needed)
+bind -n S-Left previous-window
+bind -n S-Right next-window
+
+# Copy mode vim bindings
+setw -g mode-keys vi
+bind -T copy-mode-vi v send -X begin-selection
+bind -T copy-mode-vi y send -X copy-pipe-and-cancel "pbcopy"
+bind -T copy-mode-vi MouseDragEnd1Pane send -X copy-pipe-and-cancel "pbcopy"
+
+# -----------------------------------------------------------------------------
+# Theme - Matching Omarchy/Ghostty dark theme
+# Colors: bg=#0a0f0c, fg=#e8ede9, accent=#5ec4a0
+# -----------------------------------------------------------------------------
+set -g status-style "bg=#0a0f0c,fg=#e8ede9"
+set -g status-left-length 40
+set -g status-right-length 60
+
+# Status bar
+set -g status-left "#[fg=#0a0f0c,bg=#5ec4a0,bold] #S #[fg=#5ec4a0,bg=#0a0f0c]"
+set -g status-right "#{?client_prefix,#[fg=#0a0f0c,bg=#e8d080,bold] PREFIX #[default],}#[fg=#607068]%Y-%m-%d #[fg=#e8ede9]%H:%M #[fg=#5ec4a0,bg=#0a0f0c]#[fg=#0a0f0c,bg=#5ec4a0,bold] #h "
+
+# Window status
+set -g window-status-format "#[fg=#607068] #I:#W "
+set -g window-status-current-format "#[fg=#e8d080,bold] #I:#W "
+set -g window-status-separator ""
+
+# Pane borders
+set -g pane-border-style "fg=#607068"
+set -g pane-active-border-style "fg=#5ec4a0"
+
+# Message style
+set -g message-style "bg=#e8d080,fg=#0a0f0c"
+
+# -----------------------------------------------------------------------------
+# Plugins (TPM - Tmux Plugin Manager)
+# Install: git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+# Press prefix + I to install plugins
+# -----------------------------------------------------------------------------
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @plugin 'tmux-plugins/tmux-continuum'
+
+# Auto-restore last saved session
+set -g @continuum-restore 'on'
+
+# Initialize TPM (keep this line at the very bottom)
+run '~/.tmux/plugins/tpm/tpm'

--- a/universal/.opencode/opencode.json
+++ b/universal/.opencode/opencode.json
@@ -3,6 +3,13 @@
 	"plugin": ["opencode-gemini-auth@latest", "opencode-anthropic-auth@latest"],
 	"model": "anthropic/claude-opus-4-6",
 	"small_model": "anthropic/claude-haiku-4-5",
+	"mcp": {
+		"gh_grep": {
+			"type": "remote",
+			"url": "https://mcp.grep.app",
+			"enabled": true
+		}
+	},
 	"permission": {
 		"bash": "allow",
 		"read": "allow",


### PR DESCRIPTION
Adds an Omarchy-style AeroSpace setup for macOS.

Changes:
- osx/config/.aerospace.toml: Cmd+1..9 focuses workspace, Cmd+Shift+1..9 moves focused window and follows it (Alt bindings kept as fallback).
- osx/README.md: install/copy/permissions + reload instructions.
- Also includes previously-uncommitted local changes committed separately: tmux config backup + README platform focus clarification.

Setup:
- brew install --cask nikitabobko/tap/aerospace
- cp osx/config/.aerospace.toml ~/.aerospace.toml
- System Settings -> Privacy & Security -> Accessibility -> enable AeroSpace
- aerospace reload-config

Test:
- TOML parses cleanly (python tomllib).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Deprecated Linux (Pop!_OS/Ubuntu) setup in favor of macOS and linux-omarchy platforms.
  * Restructured Quick Start section and repository documentation to reflect current platform focus with migration guidance.
  * Added deprecation notices directing users toward recommended setup directories.

* **New Features**
  * Added tmux configuration for macOS with Omarchy-style customizations, plugins, and keybindings.
  * Introduced AeroSpace tiling window manager configuration for macOS with workspace management and accessibility setup.
  * Enabled GitHub grep integration for code search capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->