### PR TITLE
AeroSpace: add Cmd+Ctrl+Arrow swap bindings

### DIFF
--- a/osx/config/.aerospace.toml
+++ b/osx/config/.aerospace.toml
@@ -54,6 +54,12 @@ persistent-workspaces = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     alt-shift-k = 'move up'
     alt-shift-l = 'move right'
 
+    # Omarchy-esque "move window around" on arrow keys (swap positions)
+    cmd-ctrl-left = 'swap left'
+    cmd-ctrl-down = 'swap down'
+    cmd-ctrl-up = 'swap up'
+    cmd-ctrl-right = 'swap right'
+
     # Resize (defaults)
     alt-minus = 'resize smart -50'
     alt-equal = 'resize smart +50'
@@ -113,4 +119,3 @@ persistent-workspaces = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     alt-shift-j = ['join-with down', 'mode main']
     alt-shift-k = ['join-with up', 'mode main']
     alt-shift-l = ['join-with right', 'mode main']
-


### PR DESCRIPTION
Adds Omarchy-esque window rearranging bindings for AeroSpace on macOS.

- Cmd+Ctrl+Arrow swaps the focused window with the nearest window in that direction.

Files:
- osx/config/.aerospace.toml

Test:
- TOML parses cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for efficient window management. Users can now use cmd-ctrl-left, cmd-ctrl-down, cmd-ctrl-up, and cmd-ctrl-right to quickly swap the active window in the respective directions. These new shortcuts streamline window organization, enable faster navigation between multiple windows, and improve desktop productivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->