### PR TITLE
chore: add aerospace swap bindings

### DIFF
--- a/osx/config/.aerospace.toml
+++ b/osx/config/.aerospace.toml
@@ -54,6 +54,12 @@ persistent-workspaces = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     alt-shift-k = 'move up'
     alt-shift-l = 'move right'
 
+    # Omarchy-esque "move window around" on arrow keys (swap positions)
+    cmd-ctrl-left = 'swap left'
+    cmd-ctrl-down = 'swap down'
+    cmd-ctrl-up = 'swap up'
+    cmd-ctrl-right = 'swap right'
+
     # Resize (defaults)
     alt-minus = 'resize smart -50'
     alt-equal = 'resize smart +50'
@@ -113,4 +119,3 @@ persistent-workspaces = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     alt-shift-j = ['join-with down', 'mode main']
     alt-shift-k = ['join-with up', 'mode main']
     alt-shift-l = ['join-with right', 'mode main']
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new keyboard shortcuts for window swapping: Cmd+Ctrl+Left, Cmd+Ctrl+Down, Cmd+Ctrl+Up, and Cmd+Ctrl+Right.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->