### PR TITLE
feat(osx): capture AeroSpace shortcuts + screenshot hotkey remaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,14 @@ cd scripts-prompts-config
 
 # Apply backed-up macOS configs
 cp osx/config/.tmux.conf ~/.tmux.conf
+cp osx/config/.aerospace.toml ~/.aerospace.toml
 mkdir -p ~/.config/ghostty
 cp osx/config/.config/ghostty/config ~/.config/ghostty/config
+mkdir -p ~/.config/zed
+cp osx/config/zed/keymap.json ~/.config/zed/keymap.json
+
+# Resolve macOS screenshot shortcut conflicts with AeroSpace Cmd+Shift+3/4
+./osx/scripts/configure_screenshot_shortcuts.sh
 
 # Reload tmux config
 tmux source-file ~/.tmux.conf
@@ -93,6 +99,7 @@ scripts-prompts-config/
 ├── osx/                       # macOS configurations/scripts
 │   ├── README.md
 │   └── scripts/
+│       ├── configure_screenshot_shortcuts.sh
 │       └── update_packages.sh
 └── universal/                 # Cross-platform scripts and hooks
     ├── convert_to_svg.sh
@@ -252,6 +259,19 @@ Updates all package managers on macOS:
 - Global npm packages
 - Global pnpm packages
 - Checks for macOS system updates
+
+#### configure_screenshot_shortcuts.sh
+
+Remaps screenshot shortcuts so AeroSpace can own `Cmd+Shift+3/4`:
+
+```bash
+./osx/scripts/configure_screenshot_shortcuts.sh
+```
+
+**Applies:**
+- Disable `Cmd+Shift+3` screenshot hotkey
+- Remap screenshot region from `Cmd+Shift+4` to `Ctrl+Shift+4`
+- Disable screenshot toolbar `Cmd+Shift+5`
 
 ### Git Hooks
 

--- a/osx/README.md
+++ b/osx/README.md
@@ -206,6 +206,52 @@ Reload config after edits:
 aerospace reload-config
 ```
 
+Includes:
+- `Cmd+Shift+Left/Right/Up/Down` move window to another monitor and follow
+- `Alt+Shift+;`, then `r` force reset to tiled layout + flatten tree
+- `Alt+Shift+;`, then `a` explicit accordion mode (only when intended)
+
+Important:
+- By default macOS uses `Cmd+Shift+3/4` for screenshots.
+- This conflicts with AeroSpace `Cmd+Shift+3/4` workspace move bindings.
+- Run `osx/scripts/configure_screenshot_shortcuts.sh` (below) to resolve this.
+
+---
+
+## 8. Zed keybindings (global dock toggles)
+
+Backed up keymap lives at:
+- `osx/config/zed/keymap.json`
+
+Copy to your local machine:
+```bash
+mkdir -p ~/.config/zed
+cp osx/config/zed/keymap.json ~/.config/zed/keymap.json
+```
+
+Keybindings included:
+- `Ctrl+B` toggle left dock
+- `Ctrl+I` toggle right dock
+
+---
+
+## 9. Screenshot shortcut conflict fix (for AeroSpace)
+
+This script configures macOS screenshot shortcuts to avoid conflict with AeroSpace:
+- Disable macOS `Cmd+Shift+3` screenshot hotkey
+- Remap screenshot-region hotkey from `Cmd+Shift+4` to `Ctrl+Shift+4`
+- Disable screenshot toolbar `Cmd+Shift+5`
+- Leave `Cmd+Shift+4` free for AeroSpace workspace move
+
+Run:
+```bash
+chmod +x osx/scripts/configure_screenshot_shortcuts.sh
+./osx/scripts/configure_screenshot_shortcuts.sh
+```
+
+The script creates a backup at:
+- `~/Library/Preferences/com.apple.symbolichotkeys.plist.bak-YYYYMMDD-HHMMSS`
+
 ---
 
 ## Summary Checklist
@@ -219,3 +265,5 @@ aerospace reload-config
 - [ ] Copy Ghostty config and keybindings
 - [ ] Copy tmux config and reload tmux
 - [ ] Install AeroSpace + copy `~/.aerospace.toml` and enable Accessibility
+- [ ] Copy Zed keymap
+- [ ] Run screenshot shortcut remap script for AeroSpace (`Cmd+Shift+3/4` conflicts)

--- a/osx/config/.aerospace.toml
+++ b/osx/config/.aerospace.toml
@@ -40,7 +40,8 @@ persistent-workspaces = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
 [mode.main.binding]
     # Layout toggles (defaults)
     alt-slash = 'layout tiles horizontal vertical'
-    alt-comma = 'layout accordion horizontal vertical'
+    # Keep alt-comma on tiles too to avoid accidental accordion mode.
+    alt-comma = 'layout tiles horizontal vertical'
 
     # Focus (defaults)
     alt-h = 'focus left'
@@ -60,6 +61,12 @@ persistent-workspaces = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     cmd-ctrl-up = 'swap up'
     cmd-ctrl-right = 'swap right'
 
+    # Move focused window to another monitor and follow it (tiling-safe).
+    cmd-shift-left = 'move-node-to-monitor --focus-follows-window --wrap-around left'
+    cmd-shift-right = 'move-node-to-monitor --focus-follows-window --wrap-around right'
+    cmd-shift-up = 'move-node-to-monitor --focus-follows-window --wrap-around up'
+    cmd-shift-down = 'move-node-to-monitor --focus-follows-window --wrap-around down'
+
     # Resize (defaults)
     alt-minus = 'resize smart -50'
     alt-equal = 'resize smart +50'
@@ -75,6 +82,8 @@ persistent-workspaces = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     cmd-8 = 'workspace 8'
     cmd-9 = 'workspace 9'
 
+    # Cmd+Shift+3/4 conflict with macOS screenshot shortcuts by default.
+    # Run osx/scripts/configure_screenshot_shortcuts.sh to free these for AeroSpace.
     cmd-shift-1 = 'move-node-to-workspace --focus-follows-window 1'
     cmd-shift-2 = 'move-node-to-workspace --focus-follows-window 2'
     cmd-shift-3 = 'move-node-to-workspace --focus-follows-window 3'
@@ -109,10 +118,14 @@ persistent-workspaces = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     # Service mode (defaults)
     alt-shift-semicolon = 'mode service'
 
+    # Emergency fix when a window ends up floating.
+    alt-shift-t = 'layout tiling'
+
 [mode.service.binding]
     esc = ['reload-config', 'mode main']
-    r = ['flatten-workspace-tree', 'mode main'] # reset layout
+    r = ['layout tiles horizontal vertical', 'flatten-workspace-tree', 'mode main'] # reset layout
     f = ['layout floating tiling', 'mode main'] # Toggle between floating and tiling layout
+    a = ['layout accordion horizontal vertical', 'mode main']
     backspace = ['close-all-windows-but-current', 'mode main']
 
     alt-shift-h = ['join-with left', 'mode main']

--- a/osx/config/.tmux.conf
+++ b/osx/config/.tmux.conf
@@ -110,4 +110,4 @@ set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @continuum-restore 'on'
 
 # Initialize TPM (keep this line at the very bottom)
-run '~/.tmux/plugins/tpm/tpm'
+run-shell "$HOME/.tmux/plugins/tpm/tpm"

--- a/osx/scripts/configure_screenshot_shortcuts.sh
+++ b/osx/scripts/configure_screenshot_shortcuts.sh
@@ -31,7 +31,7 @@ plutil -convert json -o "$src_json" "$src_plist"
 
 jq '
   .AppleSymbolicHotKeys["28"] = {
-    "enabled": 0,
+    "enabled": false,
     "value": {
       "type": "standard",
       "parameters": [51, 20, 1179648]
@@ -45,7 +45,7 @@ jq '
     }
   }
   | .AppleSymbolicHotKeys["184"] = {
-    "enabled": 0,
+    "enabled": false,
     "value": {
       "type": "standard",
       "parameters": [53, 23, 1179648]

--- a/osx/scripts/configure_screenshot_shortcuts.sh
+++ b/osx/scripts/configure_screenshot_shortcuts.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required. Install it with: brew install jq" >&2
+  exit 1
+fi
+
+domain="com.apple.symbolichotkeys"
+plist_path="$HOME/Library/Preferences/com.apple.symbolichotkeys.plist"
+
+if [[ ! -f "$plist_path" ]]; then
+  echo "Missing expected plist: $plist_path" >&2
+  exit 1
+fi
+
+backup_path="$plist_path.bak-$(date +%Y%m%d-%H%M%S)"
+cp "$plist_path" "$backup_path"
+
+tmp_dir="$(mktemp -d /tmp/symbolichotkeys.XXXXXX)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+src_plist="$tmp_dir/source.plist"
+src_json="$tmp_dir/source.json"
+out_json="$tmp_dir/updated.json"
+out_plist="$tmp_dir/updated.plist"
+
+defaults export "$domain" - > "$src_plist"
+plutil -convert json -o "$src_json" "$src_plist"
+
+jq '
+  .AppleSymbolicHotKeys["28"] = {
+    "enabled": 0,
+    "value": {
+      "type": "standard",
+      "parameters": [51, 20, 1179648]
+    }
+  }
+  | .AppleSymbolicHotKeys["30"] = {
+    "enabled": true,
+    "value": {
+      "type": "standard",
+      "parameters": [52, 21, 393216]
+    }
+  }
+  | .AppleSymbolicHotKeys["184"] = {
+    "enabled": 0,
+    "value": {
+      "type": "standard",
+      "parameters": [53, 23, 1179648]
+    }
+  }
+' "$src_json" > "$out_json"
+
+plutil -convert xml1 -o "$out_plist" "$out_json"
+defaults import "$domain" "$out_plist"
+killall cfprefsd 2>/dev/null || true
+
+echo "Updated screenshot shortcuts in $domain:"
+defaults export "$domain" - \
+  | plutil -convert json -o - - \
+  | jq '{
+      cmd_shift_3: .AppleSymbolicHotKeys["28"],
+      screenshot_region: .AppleSymbolicHotKeys["30"],
+      cmd_shift_5_toolbar: .AppleSymbolicHotKeys["184"]
+    }'
+
+echo "Backup saved to: $backup_path"


### PR DESCRIPTION
## Summary
- add reproducible macOS shortcut remap script at Updated screenshot shortcuts in com.apple.symbolichotkeys:
{
  "cmd_shift_3": {
    "enabled": 0,
    "value": {
      "type": "standard",
      "parameters": [
        51,
        20,
        1179648
      ]
    }
  },
  "screenshot_region": {
    "enabled": true,
    "value": {
      "type": "standard",
      "parameters": [
        52,
        21,
        393216
      ]
    }
  },
  "cmd_shift_5_toolbar": {
    "enabled": 0,
    "value": {
      "type": "standard",
      "parameters": [
        53,
        23,
        1179648
      ]
    }
  }
}
Backup saved to: /Users/anandpant/Library/Preferences/com.apple.symbolichotkeys.plist.bak-20260216-143548
- document AeroSpace conflict handling and key workflow in 
- document/copy Zed global keymap ( / ) in 
- update top-level  macOS quick start + utility scripts section
- fix tmux TPM bootstrap path in  ()
- improve AeroSpace defaults in :
  - keep  on tiles (avoid accidental accordion)
  - add monitor move+follow bindings on 
  - add stronger reset ( mode ) and explicit accordion toggle ()
  - document  macOS conflict inline

## Screenshot Remap Behavior
The script now sets:
-  disabled
- screenshot region moved from  to 
-  disabled

## Validation
- 
- executed Updated screenshot shortcuts in com.apple.symbolichotkeys:
{
  "cmd_shift_3": {
    "enabled": 0,
    "value": {
      "type": "standard",
      "parameters": [
        51,
        20,
        1179648
      ]
    }
  },
  "screenshot_region": {
    "enabled": true,
    "value": {
      "type": "standard",
      "parameters": [
        52,
        21,
        393216
      ]
    }
  },
  "cmd_shift_5_toolbar": {
    "enabled": 0,
    "value": {
      "type": "standard",
      "parameters": [
        53,
        23,
        1179648
      ]
    }
  }
}
Backup saved to: /Users/anandpant/Library/Preferences/com.apple.symbolichotkeys.plist.bak-20260216-143548 locally and verified resulting  values
- reloaded AeroSpace and validated workspace/layout behavior with updated bindings
- reloaded tmux and verified prefix remains 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated macOS screenshot shortcut remapping (with backup and status output).
  * New keyboard shortcuts to move windows between monitors and a quick tiling emergency binding.

* **Documentation**
  * Updated macOS setup and quick-start docs with instructions for keymap copy and running the screenshot remap workflow.
  * Added notes on resolving macOS screenshot conflicts.

* **Configuration**
  * Adjusted tiling/accordion behavior and added explicit layout reset steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->