### PR TITLE
Add tmux-first WezTerm profile + auto-approve/merge workflow

### DIFF
--- a/.github/workflows/auto-approve-automerge.yml
+++ b/.github/workflows/auto-approve-automerge.yml
@@ -1,0 +1,30 @@
+name: Auto Approve And Merge Owner PRs
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-approve-and-merge:
+    if: github.event.pull_request.draft == false && github.event.pull_request.user.login == github.repository_owner
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-approve PR
+        uses: hmarr/auto-approve-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ cp osx/config/.tmux.conf ~/.tmux.conf
 cp osx/config/.aerospace.toml ~/.aerospace.toml
 mkdir -p ~/.config/ghostty
 cp osx/config/.config/ghostty/config ~/.config/ghostty/config
+mkdir -p ~/.config/wezterm
+cp osx/config/.config/wezterm/wezterm.lua ~/.config/wezterm/wezterm.lua
 mkdir -p ~/.config/zed
 cp osx/config/zed/keymap.json ~/.config/zed/keymap.json
 

--- a/osx/README.md
+++ b/osx/README.md
@@ -126,14 +126,14 @@ cmd + shift - t [
   "Google Chrome" ~
   "Arc" ~
   "Safari" ~
-  * : open -a Ghostty
+  * : open -a WezTerm
 ]
 cmd + shift - b : open -a "Google Chrome"
 cmd + shift - f : open -a Finder
 cmd + shift - a : open -a ChatGPT
 
 # If you want true Omarchy, but it conflicts with send/submit in apps:
-# cmd - return : open -a Ghostty
+# cmd - return : open -a WezTerm
 ```
 
 Start the service and grant Accessibility permissions to `skhd`:
@@ -164,6 +164,37 @@ Keybindings included:
 
 ---
 
+## 5b. WezTerm (tmux-first alternative)
+
+Backed up WezTerm config lives at:
+- `osx/config/.config/wezterm/wezterm.lua`
+
+Install:
+```bash
+brew install --cask wezterm
+```
+
+Copy to your local machine:
+```bash
+mkdir -p ~/.config/wezterm
+cp osx/config/.config/wezterm/wezterm.lua ~/.config/wezterm/wezterm.lua
+```
+
+Behavior:
+- Always launches into `tmux new-session -A -s main`
+- Cmd+D split right (tmux pane)
+- Cmd+Shift+D split down (tmux pane)
+- Cmd+T new tmux window
+- Cmd+W kill tmux pane
+- Cmd+Shift+{/} previous/next tmux window
+- Cmd+N new macOS WezTerm window (reattaches to `main`)
+- Cmd+= / Cmd+- / Cmd+0 font zoom controls
+
+Notes:
+- This assumes your tmux prefix is `Ctrl+Space` (matches `osx/config/.tmux.conf`).
+
+---
+
 ## 6. Tmux (Omarchy-style on macOS)
 
 Backed up tmux config lives at:
@@ -179,7 +210,7 @@ Includes:
 - `Ctrl+Space` prefix (`C-b` unbound)
 - Omarchy-style statusline and pane colors
 - Vim pane movement/resizing + mouse support
-- Ghostty truecolor compatibility (`xterm-ghostty:RGB`)
+- Truecolor compatibility for Ghostty and WezTerm (`xterm-ghostty:RGB`, `wezterm:RGB`)
 - TPM plugins: sensible, resurrect, continuum
 
 ---
@@ -262,7 +293,7 @@ The script creates a backup at:
 - [ ] Add Omarchy-style aliases/functions to `~/.zshrc`
 - [ ] Create `~/.config/starship.toml`
 - [ ] Install and configure `skhd`, enable Accessibility, start service
-- [ ] Copy Ghostty config and keybindings
+- [ ] Copy Ghostty config and keybindings (or WezTerm config)
 - [ ] Copy tmux config and reload tmux
 - [ ] Install AeroSpace + copy `~/.aerospace.toml` and enable Accessibility
 - [ ] Copy Zed keymap

--- a/osx/config/.config/wezterm/wezterm.lua
+++ b/osx/config/.config/wezterm/wezterm.lua
@@ -1,0 +1,86 @@
+local wezterm = require("wezterm")
+local act = wezterm.action
+
+local config = wezterm.config_builder()
+
+local function tmux_command(command)
+  return act.Multiple({
+    act.SendKey({ key = "Space", mods = "CTRL" }),
+    act.SendKey({ key = ":" }),
+    act.SendString(command),
+    act.SendKey({ key = "Enter" }),
+  })
+end
+
+local builtin_schemes = wezterm.get_builtin_color_schemes()
+if builtin_schemes["Tokyo Night Storm"] then
+  config.color_scheme = "Tokyo Night Storm"
+elseif builtin_schemes["Catppuccin Mocha"] then
+  config.color_scheme = "Catppuccin Mocha"
+else
+  config.colors = {
+    foreground = "#e8ede9",
+    background = "#0a0f0c",
+    cursor_bg = "#5ec4a0",
+    cursor_fg = "#0a0f0c",
+    selection_bg = "#27362f",
+    selection_fg = "#e8ede9",
+  }
+end
+
+config.default_prog = {
+  os.getenv("SHELL") or "/bin/zsh",
+  "-l",
+  "-c",
+  "exec tmux new-session -A -s main",
+}
+
+config.font = wezterm.font_with_fallback({
+  "JetBrainsMono Nerd Font Mono",
+  "JetBrainsMono Nerd Font",
+  "Menlo",
+})
+config.font_size = 14.0
+config.line_height = 1.05
+config.window_padding = {
+  left = 12,
+  right = 12,
+  top = 10,
+  bottom = 10,
+}
+
+config.use_fancy_tab_bar = false
+config.hide_tab_bar_if_only_one_tab = true
+config.tab_bar_at_bottom = true
+config.window_decorations = "RESIZE"
+config.macos_window_background_blur = 20
+config.native_macos_fullscreen_mode = true
+config.automatically_reload_config = true
+
+config.keys = {
+  { key = "c", mods = "CMD", action = act.CopyTo("Clipboard") },
+  { key = "v", mods = "CMD", action = act.PasteFrom("Clipboard") },
+
+  -- Keep Ghostty muscle-memory, but route to tmux-native commands.
+  { key = "d", mods = "CMD", action = tmux_command([[split-window -h -c "#{pane_current_path}"]]) },
+  {
+    key = "d",
+    mods = "CMD|SHIFT",
+    action = tmux_command([[split-window -v -c "#{pane_current_path}"]]),
+  },
+  { key = "w", mods = "CMD", action = tmux_command("kill-pane") },
+  { key = "t", mods = "CMD", action = tmux_command([[new-window -c "#{pane_current_path}"]]) },
+  { key = "[", mods = "CMD|SHIFT", action = tmux_command("previous-window") },
+  { key = "]", mods = "CMD|SHIFT", action = tmux_command("next-window") },
+
+  -- Keep macOS-style behavior for new terminal windows and zoom.
+  { key = "n", mods = "CMD", action = act.SpawnWindow },
+  { key = "=", mods = "CMD", action = act.IncreaseFontSize },
+  { key = "-", mods = "CMD", action = act.DecreaseFontSize },
+  { key = "0", mods = "CMD", action = act.ResetFontSize },
+
+  -- Shift+Enter sends ESC+CR for Claude Code accept behavior.
+  { key = "Enter", mods = "SHIFT", action = act.SendString("\x1b\r") },
+}
+
+return config

--- a/osx/config/.tmux.conf
+++ b/osx/config/.tmux.conf
@@ -15,6 +15,7 @@ bind C-Space send-prefix
 # -----------------------------------------------------------------------------
 set -g default-terminal "tmux-256color"
 set -ag terminal-overrides ",xterm-ghostty:RGB"
+set -ag terminal-overrides ",wezterm:RGB"
 # Keep truecolor for common xterm-style clients too.
 set -ag terminal-overrides ",xterm-256color:RGB"
 set -g history-limit 50000


### PR DESCRIPTION
## Summary
- add `osx/config/.config/wezterm/wezterm.lua` with tmux-first startup (`tmux new-session -A -s main`)
- mirror existing Ghostty muscle-memory shortcuts (`Cmd+D`, `Cmd+Shift+D`, `Cmd+T`, `Cmd+W`, tab nav, font controls)
- add WezTerm truecolor override in `osx/config/.tmux.conf`
- update `README.md` and `osx/README.md` with WezTerm install/apply instructions
- add GitHub Actions workflow to auto-approve owner PRs and enable auto-merge

## Validation
- installed and verified `wezterm` locally (`wezterm 20240203-110809-5046fc22`)
- confirmed `tmux` present (`tmux 3.6a`)
- validated WezTerm config parsing via `wezterm --config-file ... show-keys`
- confirmed auto-created `tmux` session `main` on launch
