### PR TITLE
Backup Neovim config in universal

### DIFF
--- a/universal/.config/nvim/init.lua
+++ b/universal/.config/nvim/init.lua
@@ -1,0 +1,2 @@
+-- bootstrap lazy.nvim, LazyVim and your plugins
+require("config.lazy")

--- a/universal/.config/nvim/lazy-lock.json
+++ b/universal/.config/nvim/lazy-lock.json
@@ -1,0 +1,126 @@
+{
+  "LazyVim": {
+    "branch": "main",
+    "commit": "c64a61734fc9d45470a72603395c02137802bc6f"
+  },
+  "blink.cmp": {
+    "branch": "main",
+    "commit": "b19413d214068f316c78978b08264ed1c41830ec"
+  },
+  "catppuccin": {
+    "branch": "main",
+    "commit": "ce4a8e0d5267e67056f9f4dcf6cb1d0933c8ca00"
+  },
+  "conform.nvim": {
+    "branch": "master",
+    "commit": "4993e07fac6679d0a5005aa7499e0bad2bd39f19"
+  },
+  "flash.nvim": {
+    "branch": "main",
+    "commit": "fcea7ff883235d9024dc41e638f164a450c14ca2"
+  },
+  "friendly-snippets": {
+    "branch": "main",
+    "commit": "572f5660cf05f8cd8834e096d7b4c921ba18e175"
+  },
+  "gitsigns.nvim": {
+    "branch": "main",
+    "commit": "5813e4878748805f1518cee7abb50fd7205a3a48"
+  },
+  "grug-far.nvim": {
+    "branch": "main",
+    "commit": "b58b2d65863f4ebad88b10a1ddd519e5380466e0"
+  },
+  "lazy.nvim": {
+    "branch": "main",
+    "commit": "85c7ff3711b730b4030d03144f6db6375044ae82"
+  },
+  "lazydev.nvim": {
+    "branch": "main",
+    "commit": "5231c62aa83c2f8dc8e7ba957aa77098cda1257d"
+  },
+  "lualine.nvim": {
+    "branch": "master",
+    "commit": "47f91c416daef12db467145e16bed5bbfe00add8"
+  },
+  "mason-lspconfig.nvim": {
+    "branch": "main",
+    "commit": "7d527c76c43f46294de9c19d39c5a86317809b4b"
+  },
+  "mason.nvim": {
+    "branch": "main",
+    "commit": "57e5a8addb8c71fb063ee4acda466c7cf6ad2800"
+  },
+  "mini.ai": {
+    "branch": "main",
+    "commit": "bfb26d9072670c3aaefab0f53024b2f3729c8083"
+  },
+  "mini.icons": {
+    "branch": "main",
+    "commit": "ff2e4f1d29f659cc2bad0f9256f2f6195c6b2428"
+  },
+  "mini.pairs": {
+    "branch": "main",
+    "commit": "472ec50092a3314ec285d2db2baa48602d71fe93"
+  },
+  "noice.nvim": {
+    "branch": "main",
+    "commit": "7bfd942445fb63089b59f97ca487d605e715f155"
+  },
+  "nui.nvim": {
+    "branch": "main",
+    "commit": "de740991c12411b663994b2860f1a4fd0937c130"
+  },
+  "nvim-lint": {
+    "branch": "master",
+    "commit": "d1118791070d090777398792a73032a0ca5c79ff"
+  },
+  "nvim-lspconfig": {
+    "branch": "master",
+    "commit": "effe4bf2e1afb881ea67291c648b68dd3dfc927a"
+  },
+  "nvim-treesitter": {
+    "branch": "main",
+    "commit": "17885756e63df73ed90db62e4630f744ceda6514"
+  },
+  "nvim-treesitter-textobjects": {
+    "branch": "main",
+    "commit": "63c4dce4a56312ef1bdeafd16bdefa008fcc950a"
+  },
+  "nvim-ts-autotag": {
+    "branch": "main",
+    "commit": "c4ca798ab95b316a768d51eaaaee48f64a4a46bc"
+  },
+  "persistence.nvim": {
+    "branch": "main",
+    "commit": "b20b2a7887bd39c1a356980b45e03250f3dce49c"
+  },
+  "plenary.nvim": {
+    "branch": "master",
+    "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509"
+  },
+  "snacks.nvim": {
+    "branch": "main",
+    "commit": "fe7cfe9800a182274d0f868a74b7263b8c0c020b"
+  },
+  "todo-comments.nvim": {
+    "branch": "main",
+    "commit": "31e3c38ce9b29781e4422fc0322eb0a21f4e8668"
+  },
+  "tokyonight.nvim": {
+    "branch": "main",
+    "commit": "5da1b76e64daf4c5d410f06bcb6b9cb640da7dfd"
+  },
+  "trouble.nvim": {
+    "branch": "main",
+    "commit": "bd67efe408d4816e25e8491cc5ad4088e708a69a"
+  },
+  "ts-comments.nvim": {
+    "branch": "main",
+    "commit": "123a9fb12e7229342f807ec9e6de478b1102b041"
+  },
+  "which-key.nvim": {
+    "branch": "main",
+    "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a"
+  }
+}

--- a/universal/.config/nvim/lazyvim.json
+++ b/universal/.config/nvim/lazyvim.json
@@ -1,0 +1,10 @@
+{
+  "extras": [
+
+  ],
+  "install_version": 8,
+  "news": {
+    "NEWS.md": "11866"
+  },
+  "version": 8
+}

--- a/universal/.config/nvim/lua/config/autocmds.lua
+++ b/universal/.config/nvim/lua/config/autocmds.lua
@@ -1,0 +1,3 @@
+-- Autocmds are automatically loaded on the VeryLazy event
+-- Default autocmds that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/autocmds.lua
+-- Add any additional autocmds here

--- a/universal/.config/nvim/lua/config/keymaps.lua
+++ b/universal/.config/nvim/lua/config/keymaps.lua
@@ -1,0 +1,3 @@
+-- Keymaps are automatically loaded on the VeryLazy event
+-- Default keymaps that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/keymaps.lua
+-- Add any additional keymaps here

--- a/universal/.config/nvim/lua/config/lazy.lua
+++ b/universal/.config/nvim/lua/config/lazy.lua
@@ -1,0 +1,51 @@
+-- Bootstrap lazy.nvim
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not (vim.uv or vim.loop).fs_stat(lazypath) then
+  local lazyrepo = "https://github.com/folke/lazy.nvim.git"
+  local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })
+  if vim.v.shell_error ~= 0 then
+    vim.api.nvim_echo({
+      { "Failed to clone lazy.nvim:\n", "ErrorMsg" },
+      { out, "WarningMsg" },
+      { "\nPress any key to exit..." },
+    }, true, {})
+    vim.fn.getchar()
+    os.exit(1)
+  end
+end
+vim.opt.rtp:prepend(lazypath)
+
+-- Make sure to setup `mapleader` and `maplocalleader` before
+-- loading lazy.nvim so that mappings are correct.
+vim.g.mapleader = " "
+vim.g.maplocalleader = "\\"
+
+-- Setup lazy.nvim
+require("lazy").setup({
+  spec = {
+    -- Import LazyVim and its plugins
+    { "LazyVim/LazyVim", import = "lazyvim.plugins" },
+    -- Import any custom plugins from lua/plugins/
+    { import = "plugins" },
+  },
+  defaults = {
+    lazy = false,
+    version = false, -- always use the latest git commit
+  },
+  install = { colorscheme = { "catppuccin", "tokyonight", "habamax" } },
+  checker = {
+    enabled = true,
+    notify = false,
+  },
+  performance = {
+    rtp = {
+      disabled_plugins = {
+        "gzip",
+        "tarPlugin",
+        "tohtml",
+        "tutor",
+        "zipPlugin",
+      },
+    },
+  },
+})

--- a/universal/.config/nvim/lua/config/options.lua
+++ b/universal/.config/nvim/lua/config/options.lua
@@ -1,0 +1,7 @@
+-- Options are automatically loaded before lazy.nvim startup
+-- Default options that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/options.lua
+-- Add any additional options here
+
+-- Omarchy-style options
+vim.opt.relativenumber = false
+vim.opt.swapfile = false

--- a/universal/.config/nvim/lua/plugins/colorscheme.lua
+++ b/universal/.config/nvim/lua/plugins/colorscheme.lua
@@ -1,0 +1,14 @@
+return {
+  {
+    "catppuccin/nvim",
+    opts = {
+      flavour = "mocha",
+    },
+  },
+  {
+    "LazyVim/LazyVim",
+    opts = {
+      colorscheme = "catppuccin",
+    },
+  },
+}

--- a/universal/.config/nvim/lua/plugins/disabled.lua
+++ b/universal/.config/nvim/lua/plugins/disabled.lua
@@ -1,0 +1,3 @@
+return {
+  { "akinsho/bufferline.nvim", enabled = false },
+}


### PR DESCRIPTION
## Summary
- back up current Neovim config to `universal/.config/nvim`
- includes the current plugin lockfile and plugin overrides
- Copilot is not included in this backup

## Validation
- `jq empty universal/.config/nvim/lazy-lock.json universal/.config/nvim/lazyvim.json`
- `XDG_CONFIG_HOME=/Users/anandpant/scripts-prompts-config/universal/.config nvim --headless '+qa'`
- `git diff --cached --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Neovim editor configuration with plugin manager bootstrap.
  * Added plugin lockfile snapshot for consistent plugin versions.
  * Configured default editor settings and keybinding placeholders.
  * Added colorscheme configuration with default theme selection.
  * Disabled specific UI plugin to optimize performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->