### PR TITLE
Add skill install command examples

### DIFF
--- a/universal/.agents/README.md
+++ b/universal/.agents/README.md
@@ -10,6 +10,24 @@ These are maintained in this folder under `skills/`:
 - `readme-maintainer`
 - `workos-convex-authkit`
 
+## Install From This Repo
+
+Use this repository as the source for shared custom skills:
+
+```bash
+# List available skills
+npx skills add anand-testcompare/scripts-prompts-config -l
+
+# Install one skill globally for Codex
+npx skills add anand-testcompare/scripts-prompts-config \
+  --skill convex-delete-deployments \
+  --agent codex \
+  -g -y
+
+# Install all skills from this repo globally
+npx skills add anand-testcompare/scripts-prompts-config --all -g
+```
+
 ## Upstream Skills (Install Instead of Copying)
 
 These are tracked as upstream installs from `~/.agents/.skill-lock.json` and should be installed via `npx skills add`.


### PR DESCRIPTION
## Summary
- add install examples for skills published from this repository
- include list, single-skill global install, and all-skills global install commands

## Files
- universal/.agents/README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced new "Install From This Repo" section with detailed instructions for using the repository as a centralized source for shared custom skills
  * Significantly expanded the upstream skills section with four explicit practical examples and their corresponding installation commands
  * Enhanced documentation clarity for understanding different custom skill sourcing and management options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->