### PR TITLE
Remap macOS screenshot shortcuts to Cmd+Ctrl+3/4/5

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,9 +271,9 @@ Remaps screenshot shortcuts so AeroSpace can own `Cmd+Shift+3/4`:
 ```
 
 **Applies:**
-- Disable `Cmd+Shift+3` screenshot hotkey
-- Remap screenshot region from `Cmd+Shift+4` to `Ctrl+Shift+4`
-- Disable screenshot toolbar `Cmd+Shift+5`
+- Remap screenshot full screen to `Cmd+Ctrl+3`
+- Remap screenshot region to `Cmd+Ctrl+4`
+- Remap screenshot toolbar to `Cmd+Ctrl+5`
 
 ### Git Hooks
 

--- a/osx/README.md
+++ b/osx/README.md
@@ -243,7 +243,7 @@ Includes:
 - `Alt+Shift+;`, then `a` explicit accordion mode (only when intended)
 
 Important:
-- By default macOS uses `Cmd+Shift+3/4` for screenshots.
+- By default macOS uses `Cmd+Shift+3/4/5` for screenshots.
 - This conflicts with AeroSpace `Cmd+Shift+3/4` workspace move bindings.
 - Run `osx/scripts/configure_screenshot_shortcuts.sh` (below) to resolve this.
 
@@ -269,10 +269,10 @@ Keybindings included:
 ## 9. Screenshot shortcut conflict fix (for AeroSpace)
 
 This script configures macOS screenshot shortcuts to avoid conflict with AeroSpace:
-- Disable macOS `Cmd+Shift+3` screenshot hotkey
-- Remap screenshot-region hotkey from `Cmd+Shift+4` to `Ctrl+Shift+4`
-- Disable screenshot toolbar `Cmd+Shift+5`
-- Leave `Cmd+Shift+4` free for AeroSpace workspace move
+- Remap screenshot full-screen from `Cmd+Shift+3` to `Cmd+Ctrl+3`
+- Remap screenshot region from `Cmd+Shift+4` to `Cmd+Ctrl+4`
+- Remap screenshot toolbar from `Cmd+Shift+5` to `Cmd+Ctrl+5`
+- Leave `Cmd+Shift+3/4/5` free for tiling-manager bindings
 
 Run:
 ```bash
@@ -282,6 +282,7 @@ chmod +x osx/scripts/configure_screenshot_shortcuts.sh
 
 The script creates a backup at:
 - `~/Library/Preferences/com.apple.symbolichotkeys.plist.bak-YYYYMMDD-HHMMSS`
+- `osx/config/screenshot-shortcuts-cmd-ctrl-345.json` (tracked snapshot of the intended mapping)
 
 ---
 
@@ -297,4 +298,4 @@ The script creates a backup at:
 - [ ] Copy tmux config and reload tmux
 - [ ] Install AeroSpace + copy `~/.aerospace.toml` and enable Accessibility
 - [ ] Copy Zed keymap
-- [ ] Run screenshot shortcut remap script for AeroSpace (`Cmd+Shift+3/4` conflicts)
+- [ ] Run screenshot shortcut remap script for AeroSpace (`Cmd+Shift+3/4/5` conflicts)

--- a/osx/config/screenshot-shortcuts-cmd-ctrl-345.json
+++ b/osx/config/screenshot-shortcuts-cmd-ctrl-345.json
@@ -1,0 +1,37 @@
+{
+  "AppleSymbolicHotKeys": {
+    "28": {
+      "enabled": true,
+      "value": {
+        "type": "standard",
+        "parameters": [
+          51,
+          20,
+          1310720
+        ]
+      }
+    },
+    "30": {
+      "enabled": true,
+      "value": {
+        "type": "standard",
+        "parameters": [
+          52,
+          21,
+          1310720
+        ]
+      }
+    },
+    "184": {
+      "enabled": true,
+      "value": {
+        "type": "standard",
+        "parameters": [
+          53,
+          23,
+          1310720
+        ]
+      }
+    }
+  }
+}

--- a/osx/scripts/configure_screenshot_shortcuts.sh
+++ b/osx/scripts/configure_screenshot_shortcuts.sh
@@ -31,24 +31,24 @@ plutil -convert json -o "$src_json" "$src_plist"
 
 jq '
   .AppleSymbolicHotKeys["28"] = {
-    "enabled": false,
+    "enabled": true,
     "value": {
       "type": "standard",
-      "parameters": [51, 20, 1179648]
+      "parameters": [51, 20, 1310720]
     }
   }
   | .AppleSymbolicHotKeys["30"] = {
     "enabled": true,
     "value": {
       "type": "standard",
-      "parameters": [52, 21, 393216]
+      "parameters": [52, 21, 1310720]
     }
   }
   | .AppleSymbolicHotKeys["184"] = {
-    "enabled": false,
+    "enabled": true,
     "value": {
       "type": "standard",
-      "parameters": [53, 23, 1179648]
+      "parameters": [53, 23, 1310720]
     }
   }
 ' "$src_json" > "$out_json"
@@ -56,14 +56,15 @@ jq '
 plutil -convert xml1 -o "$out_plist" "$out_json"
 defaults import "$domain" "$out_plist"
 killall cfprefsd 2>/dev/null || true
+killall SystemUIServer 2>/dev/null || true
 
 echo "Updated screenshot shortcuts in $domain:"
 defaults export "$domain" - \
   | plutil -convert json -o - - \
   | jq '{
-      cmd_shift_3: .AppleSymbolicHotKeys["28"],
-      screenshot_region: .AppleSymbolicHotKeys["30"],
-      cmd_shift_5_toolbar: .AppleSymbolicHotKeys["184"]
+      cmd_ctrl_3: .AppleSymbolicHotKeys["28"],
+      cmd_ctrl_4: .AppleSymbolicHotKeys["30"],
+      cmd_ctrl_5: .AppleSymbolicHotKeys["184"]
     }'
 
 echo "Backup saved to: $backup_path"


### PR DESCRIPTION
## Summary
- update screenshot shortcut script to map screenshot hotkeys to `Cmd+Ctrl+3/4/5`
- restart macOS preference services after import for immediate effect
- update docs to reflect new shortcut mapping
- add tracked snapshot backup at `osx/config/screenshot-shortcuts-cmd-ctrl-345.json`

## Applied globally
- ran `./osx/scripts/configure_screenshot_shortcuts.sh`
- verified hotkeys 28, 30, 184 now use modifier `1310720` (Cmd+Ctrl)

## Validation
- bash -n osx/scripts/configure_screenshot_shortcuts.sh
- defaults export com.apple.symbolichotkeys ... (verified 28/30/184)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated macOS screenshot shortcut documentation with expanded configuration examples and remapping guidelines.

* **New Features**
  * Added support for remapping macOS screenshot shortcuts to Cmd+Ctrl combinations as an alternative to default shortcuts.
  * Enhanced configuration automation with system restart capability when applying shortcut changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->