### PR TITLE
feat(osx): keep new app windows in current workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,16 @@ cd scripts-prompts-config
 # Apply backed-up macOS configs
 cp osx/config/.tmux.conf ~/.tmux.conf
 cp osx/config/.aerospace.toml ~/.aerospace.toml
+cp osx/config/.skhdrc ~/.skhdrc
 mkdir -p ~/.config/ghostty
 cp osx/config/.config/ghostty/config ~/.config/ghostty/config
 mkdir -p ~/.config/wezterm
 cp osx/config/.config/wezterm/wezterm.lua ~/.config/wezterm/wezterm.lua
 mkdir -p ~/.config/zed
 cp osx/config/zed/keymap.json ~/.config/zed/keymap.json
+
+# Apply macOS defaults that fit AeroSpace workflows
+./osx/scripts/configure_macos_defaults.sh
 
 # Resolve macOS screenshot shortcut conflicts with AeroSpace Cmd+Shift+3/4
 ./osx/scripts/configure_screenshot_shortcuts.sh
@@ -101,6 +105,7 @@ scripts-prompts-config/
 ├── osx/                       # macOS configurations/scripts
 │   ├── README.md
 │   └── scripts/
+│       ├── configure_macos_defaults.sh
 │       ├── configure_screenshot_shortcuts.sh
 │       └── update_packages.sh
 └── universal/                 # Cross-platform scripts and hooks
@@ -235,7 +240,7 @@ Interactive development process killer with 5 escalating levels:
 
 **Levels:**
 1. **Dev servers only** - Kills processes on common dev ports (3000-3002, 5173, 8080, 4000, 8000)
-2. **+ Node processes** - Adds Node, npm, yarn, pnpm processes
+2. **+ Node processes** - Adds Node, npm, yarn, pnpm and d3k/headless-Chrome cleanup
 3. **+ Build tools** - Adds Vite, Next.js, Playwright, Jest, Vitest, Webpack
 4. **+ IDEs** - Adds VSCode, WebStorm, IntelliJ IDEA, Cursor, Zed
 5. **Nuclear option** - Everything including Docker, databases (Redis, PostgreSQL, MongoDB)
@@ -247,6 +252,24 @@ Interactive development process killer with 5 escalating levels:
 - Color-coded output for clarity
 
 ### macOS Scripts
+
+#### configure_macos_defaults.sh
+
+Applies macOS defaults that improve AeroSpace workspace behavior:
+
+```bash
+./osx/scripts/configure_macos_defaults.sh
+```
+
+**Applies:**
+- Disable app-triggered Space switching (`workspaces-auto-swoosh = false`)
+- Keep Spaces in fixed order (`mru-spaces = false`)
+- Group windows by app in Mission Control (`expose-group-apps = true`)
+
+**Optional:**
+- `./osx/scripts/configure_macos_defaults.sh --disable-separate-spaces`
+  - Also disables `Displays have separate Spaces` (`spans-displays = true`)
+  - Requires logout/login to fully apply
 
 #### update_packages.sh
 

--- a/osx/README.md
+++ b/osx/README.md
@@ -120,26 +120,40 @@ brew tap koekeishiya/formulae
 brew install skhd
 ```
 
-Create `~/.skhdrc`:
+Backed up `skhd` config lives at:
+- `osx/config/.skhdrc`
+
+Copy to your local machine:
+```bash
+cp osx/config/.skhdrc ~/.skhdrc
+```
+
+Config includes:
 ```sh
 cmd + shift - t [
   "Google Chrome" ~
   "Arc" ~
   "Safari" ~
-  * : open -a WezTerm
+  * : open -na /Applications/Ghostty.app
 ]
-cmd + shift - b : open -a "Google Chrome"
+cmd + shift - b : open -na /Applications/Helium.app
 cmd + shift - f : open -a Finder
 cmd + shift - a : open -a ChatGPT
 
 # If you want true Omarchy, but it conflicts with send/submit in apps:
-# cmd - return : open -a WezTerm
+# cmd - return : open -na /Applications/Ghostty.app
 ```
 
 Start the service and grant Accessibility permissions to `skhd`:
 ```bash
 skhd --start-service
+launchctl kickstart -k gui/$(id -u)/com.koekeishiya.skhd
 ```
+
+Notes:
+- The launcher uses `open -na` on purpose so new windows open in your current workspace instead of jumping to an existing app window in another macOS Space.
+- Expected tradeoff: each fresh app instance shows as its own icon in the Dock while running.
+- If you prefer single Dock app grouping, switch those bindings back to `open -a ...`, but macOS may jump to another Space.
 
 ---
 
@@ -241,6 +255,17 @@ Includes:
 - `Cmd+Shift+Left/Right/Up/Down` move window to another monitor and follow
 - `Alt+Shift+;`, then `r` force reset to tiled layout + flatten tree
 - `Alt+Shift+;`, then `a` explicit accordion mode (only when intended)
+- `Alt+Enter` open a fresh Ghostty app instance (`open -na`) for new workspace sessions
+
+Recommended macOS defaults for AeroSpace workflows:
+```bash
+./osx/scripts/configure_macos_defaults.sh
+```
+
+This sets:
+- Disable "When switching to an application, switch to a Space with open windows"
+- Keep Spaces in fixed order (disable automatic rearranging)
+- Enable "Group windows by application" in Mission Control
 
 Important:
 - By default macOS uses `Cmd+Shift+3/4/5` for screenshots.
@@ -266,7 +291,28 @@ Keybindings included:
 
 ---
 
-## 9. Screenshot shortcut conflict fix (for AeroSpace)
+## 9. macOS defaults script (for AeroSpace)
+
+Apply macOS defaults that work better with AeroSpace workspace behavior:
+
+```bash
+chmod +x osx/scripts/configure_macos_defaults.sh
+./osx/scripts/configure_macos_defaults.sh
+```
+
+Optional (multi-monitor): disable `Displays have separate Spaces` as well:
+
+```bash
+./osx/scripts/configure_macos_defaults.sh --disable-separate-spaces
+```
+
+Notes:
+- The script restarts Dock automatically.
+- If you pass `--disable-separate-spaces`, logout/login is required.
+
+---
+
+## 10. Screenshot shortcut conflict fix (for AeroSpace)
 
 This script configures macOS screenshot shortcuts to avoid conflict with AeroSpace:
 - Remap screenshot full-screen from `Cmd+Shift+3` to `Cmd+Ctrl+3`
@@ -293,9 +339,10 @@ The script creates a backup at:
 - [ ] Keep native `pbcopy/pbpaste/open`
 - [ ] Add Omarchy-style aliases/functions to `~/.zshrc`
 - [ ] Create `~/.config/starship.toml`
-- [ ] Install and configure `skhd`, enable Accessibility, start service
+- [ ] Install `skhd`, copy `~/.skhdrc`, enable Accessibility, restart service
 - [ ] Copy Ghostty config and keybindings (or WezTerm config)
 - [ ] Copy tmux config and reload tmux
 - [ ] Install AeroSpace + copy `~/.aerospace.toml` and enable Accessibility
+- [ ] Run `osx/scripts/configure_macos_defaults.sh` (AeroSpace-friendly macOS defaults)
 - [ ] Copy Zed keymap
 - [ ] Run screenshot shortcut remap script for AeroSpace (`Cmd+Shift+3/4/5` conflicts)

--- a/osx/config/.aerospace.toml
+++ b/osx/config/.aerospace.toml
@@ -84,6 +84,11 @@ persistent-workspaces = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     alt-minus = 'resize smart -50'
     alt-equal = 'resize smart +50'
 
+    # Open a fresh Ghostty instance in the current workspace.
+    # Pair this with macOS Mission Control setting "switch to an application"
+    # disabled so macOS won't jump to another Space.
+    alt-enter = 'exec-and-forget open -na /Applications/Ghostty.app'
+
     # Workspaces (Omarchy-style on macOS)
     cmd-1 = 'workspace 1'
     cmd-2 = 'workspace 2'

--- a/osx/config/.skhdrc
+++ b/osx/config/.skhdrc
@@ -1,0 +1,15 @@
+# Omarchy-style app launchers on macOS.
+# Use `open -na` to force fresh app instances in the current workspace.
+# Tradeoff: each instance appears as its own Dock icon.
+cmd + shift - t [
+  "Google Chrome" ~
+  "Arc" ~
+  "Safari" ~
+  * : open -na /Applications/Ghostty.app
+]
+cmd + shift - b : open -na /Applications/Helium.app
+cmd + shift - f : open -a Finder
+cmd + shift - a : open -a ChatGPT
+
+# Optional true Omarchy style:
+# cmd - return : open -na /Applications/Ghostty.app

--- a/osx/scripts/configure_macos_defaults.sh
+++ b/osx/scripts/configure_macos_defaults.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+show_help() {
+  cat <<'EOF'
+Usage: ./osx/scripts/configure_macos_defaults.sh [--disable-separate-spaces]
+
+Applies macOS defaults that pair well with AeroSpace workspace workflows.
+
+Options:
+  --disable-separate-spaces  Also disable "Displays have separate Spaces"
+                             (requires logout to fully take effect).
+  -h, --help                 Show this help text.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  show_help
+  exit 0
+fi
+
+if [[ $# -gt 1 ]]; then
+  show_help >&2
+  exit 1
+fi
+
+if [[ $# -eq 1 && "${1}" != "--disable-separate-spaces" ]]; then
+  echo "Unknown argument: ${1}" >&2
+  show_help >&2
+  exit 1
+fi
+
+needs_logout="false"
+
+apply_bool() {
+  local domain="$1"
+  local key="$2"
+  local value="$3"
+  local label="$4"
+  local before after
+
+  before="$(defaults read "$domain" "$key" 2>/dev/null || true)"
+  if [[ -z "$before" ]]; then
+    before="<unset>"
+  fi
+
+  defaults write "$domain" "$key" -bool "$value"
+  after="$(defaults read "$domain" "$key")"
+
+  printf '[ok] %s: %s -> %s\n' "$label" "$before" "$after"
+}
+
+echo "Applying macOS defaults for AeroSpace workflow..."
+
+apply_bool \
+  "com.apple.dock" \
+  "workspaces-auto-swoosh" \
+  "false" \
+  "Do not switch to another Space for existing app windows"
+
+apply_bool \
+  "com.apple.dock" \
+  "mru-spaces" \
+  "false" \
+  "Keep Spaces in a fixed order"
+
+apply_bool \
+  "com.apple.dock" \
+  "expose-group-apps" \
+  "true" \
+  "Group windows by app in Mission Control"
+
+if [[ "${1:-}" == "--disable-separate-spaces" ]]; then
+  apply_bool \
+    "com.apple.spaces" \
+    "spans-displays" \
+    "true" \
+    "Disable 'Displays have separate Spaces'"
+  needs_logout="true"
+fi
+
+killall Dock 2>/dev/null || true
+killall cfprefsd 2>/dev/null || true
+
+echo
+echo "Done. Restarted Dock to apply changes."
+if [[ "$needs_logout" == "true" ]]; then
+  echo "Logout/login is required for 'Displays have separate Spaces' to fully apply."
+fi

--- a/universal/kill-dev.sh
+++ b/universal/kill-dev.sh
@@ -51,15 +51,36 @@ kill_by_name() {
     done
 }
 
+kill_d3k_headless_chrome() {
+    local patterns=(
+        "\\.d3k/.*/chrome-profile"
+        "@d3k/.*/bin/dev3000"
+        "dev3000 .* --headless"
+    )
+    local did_print=false
+
+    for pattern in "${patterns[@]}"; do
+        local pids=$(pgrep -f "$pattern" 2>/dev/null || true)
+        if [ -n "$pids" ]; then
+            if [ "$did_print" = false ]; then
+                echo -e "${YELLOW}Killing d3k/headless Chrome processes${NC}"
+                did_print=true
+            fi
+            pkill -f "$pattern" 2>/dev/null || true
+        fi
+    done
+}
+
 level_1() {
     echo -e "${GREEN}Level 1: Killing dev server ports${NC}"
     kill_by_port 3000 3001 3002 5173 8080 4000 8000
 }
 
 level_2() {
-    echo -e "${GREEN}Level 2: Killing dev servers + Node processes${NC}"
+    echo -e "${GREEN}Level 2: Killing dev servers + Node + d3k headless Chrome${NC}"
     FORCE_KILL=true level_1
     kill_by_name "node" "npm" "yarn" "pnpm"
+    kill_d3k_headless_chrome
 }
 
 level_3() {
@@ -88,7 +109,7 @@ interactive_mode() {
         echo -e "${BLUE}Development Process Killer${NC}"
         echo "Select kill level:"
         echo "1) Dev servers only (ports 3000-3002, 5173, 8080)"
-        echo "2) + Node/npm/yarn processes"
+        echo "2) + Node/npm/yarn + d3k headless Chrome cleanup"
         echo "3) + Vite/Next.js/Playwright/build tools"
         echo "4) + IDEs (VSCode, WebStorm, Cursor, Zed)"
         echo "5) Nuclear option (everything including Docker, DBs)"


### PR DESCRIPTION
## Summary
- add an AeroSpace `alt-enter` launcher and a versioned `osx/config/.skhdrc` that use `open -na` so fresh Ghostty/Helium windows open in the active workspace
- add `osx/scripts/configure_macos_defaults.sh` and document the macOS defaults that prevent Space-jumping behavior
- harden `universal/kill-dev.sh` level 2+ to clean up stale d3k headless Chrome/dev3000 processes and update docs accordingly

## Validation
- `bash -n osx/scripts/configure_macos_defaults.sh`
- `bash -n universal/kill-dev.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added macOS hotkeys for quick app launching (Ghostty, browsers, Finder, ChatGPT).
  * Introduced automation script for optimizing macOS defaults for workspace management.

* **Documentation**
  * Expanded macOS setup instructions with new configuration steps and backup references.
  * Added examples and usage documentation for automation scripts.

* **Chores**
  * Enhanced process cleanup capabilities for development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->