### PR TITLE
Update Omarchy screenshot shortcuts to Ctrl+Shift+3/4/5

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Install the commit-msg hook from `universal/git-hooks/` (see `universal/git-hook
 ## Platform-Specific Documentation
 
 - **Linux (Pop!_OS/Ubuntu, deprecated)**: See [linux-popos/config/README.md](linux-popos/config/README.md) (legacy)
-- **Linux (Omarchy/Arch)**: See [linux-omarchy/REPLICATION-GUIDE.md](linux-omarchy/REPLICATION-GUIDE.md) for Omarchy setup details
+- **Linux (Omarchy/Arch)**: See [linux-omarchy/REPLICATION-GUIDE.md](linux-omarchy/REPLICATION-GUIDE.md) for Omarchy setup details. Screenshot shortcuts are `Ctrl+Shift+3/4/5`.
 - **macOS**: Utility scripts available in `osx/scripts/`
 
 ## Contributing

--- a/linux-omarchy/REPLICATION-GUIDE.md
+++ b/linux-omarchy/REPLICATION-GUIDE.md
@@ -216,6 +216,15 @@ unbind = SUPER, W
 bindd = SUPER, Q, Close window, killactive,
 ```
 
+### Screenshot shortcuts (Ctrl+Shift+3/4/5)
+
+Add to `~/.config/hypr/bindings.conf`:
+```bash
+bindd = CTRL SHIFT, 3, Screenshot fullscreen to clipboard, exec, omarchy-cmd-screenshot fullscreen clipboard
+bindd = CTRL SHIFT, 4, Screenshot region to clipboard, exec, omarchy-cmd-screenshot region clipboard
+bindd = CTRL SHIFT, 5, Screenshot smart to clipboard, exec, omarchy-cmd-screenshot smart clipboard
+```
+
 ### Magnet-style window movement across monitors
 
 Create `~/.local/bin/hypr-move-window`:

--- a/linux-omarchy/configs/hypr-bindings.conf
+++ b/linux-omarchy/configs/hypr-bindings.conf
@@ -44,8 +44,10 @@ bindd = SUPER, V, Paste (smart), exec, ~/.local/bin/ghostty-or-universal paste
 bindd = SUPER, T, New tab (smart), exec, ~/.local/bin/ghostty-or-universal new-tab
 bindd = SUPER, N, New window (smart), exec, ~/.local/bin/ghostty-or-universal new-window
 
-# Screenshot (macOS-style)
-bindd = SUPER SHIFT, 4, Screenshot to clipboard, exec, omarchy-cmd-screenshot smart clipboard
+# Screenshot shortcuts
+bindd = CTRL SHIFT, 3, Screenshot fullscreen to clipboard, exec, omarchy-cmd-screenshot fullscreen clipboard
+bindd = CTRL SHIFT, 4, Screenshot region to clipboard, exec, omarchy-cmd-screenshot region clipboard
+bindd = CTRL SHIFT, 5, Screenshot smart to clipboard, exec, omarchy-cmd-screenshot smart clipboard
 
 # Move window in direction (within workspace, then to monitor if at edge)
 bindd = SUPER CTRL, LEFT, Move window left, exec, ~/.local/bin/hypr-move-window l


### PR DESCRIPTION
## Summary
- change Omarchy Hypr screenshot bindings to Ctrl+Shift+3/4/5
- update replication guide with the new screenshot mapping
- add a README note for Linux Omarchy screenshot shortcuts

## Validation
- verified no Ctrl+Shift+3/4/5 collisions in active Hypr/xremap/ghostty configs
- reloaded Hyprland locally after applying live config changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new screenshot shortcuts: Ctrl+Shift+3 for fullscreen screenshots, Ctrl+Shift+4 for region selection, and Ctrl+Shift+5 for smart capture—all with automatic clipboard copying.

* **Documentation**
  * Updated guides and configuration references to include the new screenshot shortcut bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->