### PR TITLE
Update tmux clipboard and mouse defaults

### DIFF
--- a/osx/config/.tmux.conf
+++ b/osx/config/.tmux.conf
@@ -18,6 +18,8 @@ set -ag terminal-overrides ",xterm-ghostty:RGB"
 set -ag terminal-overrides ",wezterm:RGB"
 # Keep truecolor for common xterm-style clients too.
 set -ag terminal-overrides ",xterm-256color:RGB"
+# Keep clipboard integration working through tmux.
+set -g set-clipboard on
 set -g history-limit 50000
 set -g display-time 4000
 set -g status-interval 5
@@ -28,13 +30,15 @@ setw -g pane-base-index 1
 set -g renumber-windows on
 
 # Mouse support
-set -g mouse on
+set -g mouse off
 
 # -----------------------------------------------------------------------------
 # Keybindings
 # -----------------------------------------------------------------------------
 # Reload config
 bind r source-file ~/.tmux.conf \; display "Config reloaded!"
+# Toggle mouse mode so native terminal selection/Cmd-click works when needed.
+bind m if -F '#{mouse}' 'set -g mouse off \; display "Mouse OFF: native selection + Cmd-click links"' 'set -g mouse on \; display "Mouse ON: tmux mouse mode"'
 
 # Split panes using | and -
 bind | split-window -h -c "#{pane_current_path}"
@@ -72,6 +76,8 @@ setw -g mode-keys vi
 bind -T copy-mode-vi v send -X begin-selection
 bind -T copy-mode-vi y send -X copy-pipe-and-cancel "pbcopy"
 bind -T copy-mode-vi MouseDragEnd1Pane send -X copy-pipe-and-cancel "pbcopy"
+bind -T copy-mode-vi Enter send -X copy-pipe-and-cancel "pbcopy"
+bind -T copy-mode-vi O send -X copy-pipe-and-cancel "tr -d '\r\n' | xargs -I{} open '{}'"
 
 # -----------------------------------------------------------------------------
 # Theme - Matching Omarchy/Ghostty dark theme


### PR DESCRIPTION
## Summary
- enable tmux clipboard integration explicitly
- default mouse mode off and add a toggle shortcut for native selection/cmd-click when needed
- add copy-mode bindings for Enter and opening selected URLs

## Testing
- not run (config-only change)