### PR TITLE
Make WezTerm native-first by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ git clone https://github.com/yourusername/scripts-prompts-config.git
 cd scripts-prompts-config
 
 # Apply backed-up macOS configs
-cp osx/config/.tmux.conf ~/.tmux.conf
 cp osx/config/.aerospace.toml ~/.aerospace.toml
 cp osx/config/.skhdrc ~/.skhdrc
 mkdir -p ~/.config/ghostty
@@ -32,9 +31,6 @@ cp osx/config/zed/keymap.json ~/.config/zed/keymap.json
 
 # Resolve macOS screenshot shortcut conflicts with AeroSpace Cmd+Shift+3/4
 ./osx/scripts/configure_screenshot_shortcuts.sh
-
-# Reload tmux config
-tmux source-file ~/.tmux.conf
 ```
 
 ### Legacy Pop!_OS Scripts (Deprecated)

--- a/backups/wezterm-tmux-first-20260312-155522/osx/config/.config/wezterm/wezterm.lua
+++ b/backups/wezterm-tmux-first-20260312-155522/osx/config/.config/wezterm/wezterm.lua
@@ -3,6 +3,15 @@ local act = wezterm.action
 
 local config = wezterm.config_builder()
 
+-- tmux prefix is Ctrl+Space, which is ASCII NUL (\x00) on the PTY.
+local function tmux_prefix(sequence)
+  return act.SendString("\x00" .. sequence)
+end
+
+local function tmux_command(command)
+  return act.SendString("\x00:" .. command .. "\r")
+end
+
 local builtin_schemes = wezterm.get_builtin_color_schemes()
 if builtin_schemes["Tokyo Night Storm"] then
   config.color_scheme = "Tokyo Night Storm"
@@ -19,12 +28,12 @@ else
   }
 end
 
-config.unix_domains = {
-  {
-    name = "main",
-  },
+config.default_prog = {
+  os.getenv("SHELL") or "/bin/zsh",
+  "-l",
+  "-c",
+  "exec tmux new-session -A -s main",
 }
-config.default_gui_startup_args = { "connect", "main" }
 
 config.font = wezterm.font_with_fallback({
   "JetBrainsMono Nerd Font Mono",
@@ -49,52 +58,21 @@ config.macos_window_background_blur = 20
 config.native_macos_fullscreen_mode = true
 config.automatically_reload_config = true
 
-wezterm.on("update-right-status", function(window, _)
-  local workspace = window:active_workspace()
-  window:set_right_status(wezterm.format({
-    { Foreground = { Color = "#607068" } },
-    { Text = "workspace " },
-    { Foreground = { Color = "#5ec4a0" } },
-    { Text = workspace },
-    { Text = " " },
-  }))
-end)
-
 config.keys = {
   { key = "c", mods = "CMD", action = act.CopyTo("Clipboard") },
   { key = "v", mods = "CMD", action = act.PasteFrom("Clipboard") },
 
-  -- Keep Ghostty muscle-memory, but use WezTerm-native panes/tabs.
-  {
-    key = "d",
-    mods = "CMD",
-    action = act.SplitHorizontal({ domain = "CurrentPaneDomain" }),
-  },
+  -- Keep Ghostty muscle-memory, but route to tmux-native commands.
+  { key = "d", mods = "CMD", action = tmux_prefix("%") },
   {
     key = "d",
     mods = "CMD|SHIFT",
-    action = act.SplitVertical({ domain = "CurrentPaneDomain" }),
+    action = tmux_prefix('"'),
   },
-  {
-    key = "w",
-    mods = "CMD",
-    action = act.CloseCurrentPane({ confirm = false }),
-  },
-  { key = "t", mods = "CMD", action = act.SpawnTab("CurrentPaneDomain") },
-  { key = "[", mods = "CMD|SHIFT", action = act.ActivateTabRelative(-1) },
-  { key = "]", mods = "CMD|SHIFT", action = act.ActivateTabRelative(1) },
-  {
-    key = "l",
-    mods = "CMD|SHIFT",
-    action = act.ShowLauncherArgs({
-      flags = "FUZZY|TABS|WORKSPACES|LAUNCH_MENU_ITEMS",
-    }),
-  },
-  {
-    key = "p",
-    mods = "CMD|SHIFT",
-    action = act.PaneSelect,
-  },
+  { key = "w", mods = "CMD", action = tmux_command("kill-pane") },
+  { key = "t", mods = "CMD", action = tmux_prefix("c") },
+  { key = "[", mods = "CMD|SHIFT", action = tmux_prefix("p") },
+  { key = "]", mods = "CMD|SHIFT", action = tmux_prefix("n") },
 
   -- Keep macOS-style behavior for new terminal windows and zoom.
   { key = "n", mods = "CMD", action = act.SpawnWindow },

--- a/backups/wezterm-tmux-first-20260312-155522/osx/config/.tmux.conf
+++ b/backups/wezterm-tmux-first-20260312-155522/osx/config/.tmux.conf
@@ -1,0 +1,114 @@
+# =============================================================================
+# tmux configuration - Omarchy style
+# Prefix: Ctrl+Space
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Prefix key
+# -----------------------------------------------------------------------------
+unbind C-b
+set -g prefix C-Space
+bind C-Space send-prefix
+
+# -----------------------------------------------------------------------------
+# General settings
+# -----------------------------------------------------------------------------
+set -g default-terminal "tmux-256color"
+set -ag terminal-overrides ",xterm-ghostty:RGB"
+set -ag terminal-overrides ",wezterm:RGB"
+# Keep truecolor for common xterm-style clients too.
+set -ag terminal-overrides ",xterm-256color:RGB"
+set -g history-limit 50000
+set -g display-time 4000
+set -g status-interval 5
+set -g focus-events on
+set -g escape-time 0
+set -g base-index 1
+setw -g pane-base-index 1
+set -g renumber-windows on
+
+# Mouse support
+set -g mouse on
+
+# -----------------------------------------------------------------------------
+# Keybindings
+# -----------------------------------------------------------------------------
+# Reload config
+bind r source-file ~/.tmux.conf \; display "Config reloaded!"
+
+# Split panes using | and -
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+unbind '"'
+unbind %
+
+# New window in current path
+bind c new-window -c "#{pane_current_path}"
+
+# Vim-style pane navigation
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+# Vim-style pane resizing
+bind -r H resize-pane -L 5
+bind -r J resize-pane -D 5
+bind -r K resize-pane -U 5
+bind -r L resize-pane -R 5
+
+# Alt+arrow pane switching (no prefix needed)
+bind -n M-Left select-pane -L
+bind -n M-Right select-pane -R
+bind -n M-Up select-pane -U
+bind -n M-Down select-pane -D
+
+# Shift+arrow window switching (no prefix needed)
+bind -n S-Left previous-window
+bind -n S-Right next-window
+
+# Copy mode vim bindings
+setw -g mode-keys vi
+bind -T copy-mode-vi v send -X begin-selection
+bind -T copy-mode-vi y send -X copy-pipe-and-cancel "pbcopy"
+bind -T copy-mode-vi MouseDragEnd1Pane send -X copy-pipe-and-cancel "pbcopy"
+
+# -----------------------------------------------------------------------------
+# Theme - Matching Omarchy/Ghostty dark theme
+# Colors: bg=#0a0f0c, fg=#e8ede9, accent=#5ec4a0
+# -----------------------------------------------------------------------------
+set -g status-style "bg=#0a0f0c,fg=#e8ede9"
+set -g status-left-length 40
+set -g status-right-length 60
+
+# Status bar
+set -g status-left "#[fg=#0a0f0c,bg=#5ec4a0,bold] #S #[fg=#5ec4a0,bg=#0a0f0c]"
+set -g status-right "#{?client_prefix,#[fg=#0a0f0c,bg=#e8d080,bold] PREFIX #[default],}#[fg=#607068]%Y-%m-%d #[fg=#e8ede9]%H:%M #[fg=#5ec4a0,bg=#0a0f0c]#[fg=#0a0f0c,bg=#5ec4a0,bold] #h "
+
+# Window status
+set -g window-status-format "#[fg=#607068] #I:#W "
+set -g window-status-current-format "#[fg=#e8d080,bold] #I:#W "
+set -g window-status-separator ""
+
+# Pane borders
+set -g pane-border-style "fg=#607068"
+set -g pane-active-border-style "fg=#5ec4a0"
+
+# Message style
+set -g message-style "bg=#e8d080,fg=#0a0f0c"
+
+# -----------------------------------------------------------------------------
+# Plugins (TPM - Tmux Plugin Manager)
+# Install: git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+# Press prefix + I to install plugins
+# -----------------------------------------------------------------------------
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @plugin 'tmux-plugins/tmux-continuum'
+
+# Auto-restore last saved session
+set -g @continuum-restore 'on'
+
+# Initialize TPM (keep this line at the very bottom)
+run-shell "$HOME/.tmux/plugins/tpm/tpm"

--- a/osx/README.md
+++ b/osx/README.md
@@ -178,7 +178,7 @@ Keybindings included:
 
 ---
 
-## 5b. WezTerm (tmux-first alternative)
+## 5b. WezTerm (native-first default)
 
 Backed up WezTerm config lives at:
 - `osx/config/.config/wezterm/wezterm.lua`
@@ -195,21 +195,24 @@ cp osx/config/.config/wezterm/wezterm.lua ~/.config/wezterm/wezterm.lua
 ```
 
 Behavior:
-- Always launches into `tmux new-session -A -s main`
-- Cmd+D split right (tmux pane)
-- Cmd+Shift+D split down (tmux pane)
-- Cmd+T new tmux window
-- Cmd+W kill tmux pane
-- Cmd+Shift+{/} previous/next tmux window
-- Cmd+N new macOS WezTerm window (reattaches to `main`)
+- Connects the GUI to a local WezTerm mux domain named `main`
+- Native panes/tabs/workspaces, no tmux required
+- Cmd+D split right
+- Cmd+Shift+D split down
+- Cmd+T new tab
+- Cmd+W close current pane
+- Cmd+Shift+{/} previous/next tab
+- Cmd+Shift+L launcher for tabs/workspaces
+- Cmd+Shift+P pane picker
+- Cmd+N new macOS WezTerm window (attached to the same local mux domain)
 - Cmd+= / Cmd+- / Cmd+0 font zoom controls
 
 Notes:
-- This assumes your tmux prefix is `Ctrl+Space` (matches `osx/config/.tmux.conf`).
+- Using a local mux domain gives you durable local tabs/workspaces without layering tmux inside WezTerm.
 
 ---
 
-## 6. Tmux (Omarchy-style on macOS)
+## 6. Tmux (optional legacy path)
 
 Backed up tmux config lives at:
 - `osx/config/.tmux.conf`
@@ -226,6 +229,8 @@ Includes:
 - Vim pane movement/resizing + mouse support
 - Truecolor compatibility for Ghostty and WezTerm (`xterm-ghostty:RGB`, `wezterm:RGB`)
 - TPM plugins: sensible, resurrect, continuum
+
+Use this only if you explicitly want tmux for remote persistence or a terminal-agnostic workflow. The main macOS path in this repo is now WezTerm-native.
 
 ---
 
@@ -340,8 +345,7 @@ The script creates a backup at:
 - [ ] Add Omarchy-style aliases/functions to `~/.zshrc`
 - [ ] Create `~/.config/starship.toml`
 - [ ] Install `skhd`, copy `~/.skhdrc`, enable Accessibility, restart service
-- [ ] Copy Ghostty config and keybindings (or WezTerm config)
-- [ ] Copy tmux config and reload tmux
+- [ ] Copy Ghostty config and keybindings or WezTerm config
 - [ ] Install AeroSpace + copy `~/.aerospace.toml` and enable Accessibility
 - [ ] Run `osx/scripts/configure_macos_defaults.sh` (AeroSpace-friendly macOS defaults)
 - [ ] Copy Zed keymap


### PR DESCRIPTION
## Summary
- make WezTerm the default native-first terminal path instead of auto-starting tmux
- preserve the previous tmux-first WezTerm and tmux configs under backups/
- update macOS setup docs to reflect WezTerm-native panes, tabs, and local mux domains

## Verification
- WEZTERM_CONFIG_FILE=osx/config/.config/wezterm/wezterm.lua wezterm show-keys


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native WezTerm window and pane management capabilities now available.
  * Workspace display added to the status bar.

* **Documentation**
  * WezTerm repositioned as the primary macOS workflow (native-first approach).
  * Tmux reframed as an optional legacy configuration path.

* **Chores**
  * Streamlined macOS Quick Start setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->