### PR TITLE
Point macOS terminal launcher at WezTerm

### DIFF
--- a/osx/README.md
+++ b/osx/README.md
@@ -134,14 +134,14 @@ cmd + shift - t [
   "Google Chrome" ~
   "Arc" ~
   "Safari" ~
-  * : open -na /Applications/Ghostty.app
+  * : open -na /Applications/WezTerm.app
 ]
 cmd + shift - b : open -na /Applications/Helium.app
 cmd + shift - f : open -a Finder
 cmd + shift - a : open -a ChatGPT
 
 # If you want true Omarchy, but it conflicts with send/submit in apps:
-# cmd - return : open -na /Applications/Ghostty.app
+# cmd - return : open -na /Applications/WezTerm.app
 ```
 
 Start the service and grant Accessibility permissions to `skhd`:

--- a/osx/config/.skhdrc
+++ b/osx/config/.skhdrc
@@ -5,11 +5,11 @@ cmd + shift - t [
   "Google Chrome" ~
   "Arc" ~
   "Safari" ~
-  * : open -na /Applications/Ghostty.app
+  * : open -na /Applications/WezTerm.app
 ]
 cmd + shift - b : open -na /Applications/Helium.app
 cmd + shift - f : open -a Finder
 cmd + shift - a : open -a ChatGPT
 
 # Optional true Omarchy style:
-# cmd - return : open -na /Applications/Ghostty.app
+# cmd - return : open -na /Applications/WezTerm.app


### PR DESCRIPTION
## Summary
- switch the macOS skhd terminal launcher from Ghostty to WezTerm
- update the matching README snippet so docs reflect the live binding

## Verification
- updated live ~/.skhdrc and reloaded skhd locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration documentation and keybinding settings to reference WezTerm as the default terminal application instead of Ghostty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->