### PR TITLE
Fix WezTerm split cwd inheritance

### DIFF
--- a/osx/README.md
+++ b/osx/README.md
@@ -194,6 +194,12 @@ mkdir -p ~/.config/wezterm
 cp osx/config/.config/wezterm/wezterm.lua ~/.config/wezterm/wezterm.lua
 ```
 
+Enable shell integration so splits inherit the shell's current working directory:
+```bash
+printf '\nif [[ "$TERM_PROGRAM" == "WezTerm" && -f /Applications/WezTerm.app/Contents/Resources/wezterm.sh ]]; then\n  source /Applications/WezTerm.app/Contents/Resources/wezterm.sh\nfi\n' >> ~/.zshrc
+exec zsh
+```
+
 Behavior:
 - Connects the GUI to a local WezTerm mux domain named `main`
 - Native panes/tabs/workspaces, no tmux required
@@ -209,6 +215,7 @@ Behavior:
 
 Notes:
 - Using a local mux domain gives you durable local tabs/workspaces without layering tmux inside WezTerm.
+- Shell integration keeps WezTerm's tracked cwd in sync after `cd`, which is what makes `Cmd+D` and `Cmd+Shift+D` open in the directory you're actually working in.
 
 ---
 

--- a/osx/config/.config/wezterm/wezterm.lua
+++ b/osx/config/.config/wezterm/wezterm.lua
@@ -60,6 +60,37 @@ wezterm.on("update-right-status", function(window, _)
   }))
 end)
 
+local function pane_cwd_path(pane)
+  local cwd = pane:get_current_working_dir()
+  if not cwd then
+    return nil
+  end
+
+  if type(cwd) == "table" or type(cwd) == "userdata" then
+    if cwd.scheme == "file" and cwd.file_path then
+      return cwd.file_path
+    end
+    return nil
+  end
+
+  return cwd
+end
+
+local function split_in_current_cwd(direction)
+  return wezterm.action_callback(function(_, pane)
+    local split_opts = {
+      direction = direction,
+    }
+
+    local cwd = pane_cwd_path(pane)
+    if cwd then
+      split_opts.cwd = cwd
+    end
+
+    pane:split(split_opts)
+  end)
+end
+
 config.keys = {
   { key = "c", mods = "CMD", action = act.CopyTo("Clipboard") },
   { key = "v", mods = "CMD", action = act.PasteFrom("Clipboard") },
@@ -68,12 +99,12 @@ config.keys = {
   {
     key = "d",
     mods = "CMD",
-    action = act.SplitHorizontal({ domain = "CurrentPaneDomain" }),
+    action = split_in_current_cwd("Right"),
   },
   {
     key = "d",
     mods = "CMD|SHIFT",
-    action = act.SplitVertical({ domain = "CurrentPaneDomain" }),
+    action = split_in_current_cwd("Down"),
   },
   {
     key = "w",


### PR DESCRIPTION
## Summary
- make WezTerm split bindings inherit the active pane's tracked working directory
- normalize the current working directory value to a filesystem path before splitting
- document the required shell integration so cwd tracking stays accurate after `cd`

## Testing
- `wezterm --config-file osx/config/.config/wezterm/wezterm.lua ls-fonts >/dev/null`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WezTerm shell integration to synchronize the terminal's tracked working directory after directory changes.
  * Splits created with Cmd+D and Cmd+Shift+D now inherit the current working directory from the active pane.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->