### PR TITLE
Restore Ghostty as default terminal launcher

### DIFF
--- a/osx/README.md
+++ b/osx/README.md
@@ -134,14 +134,16 @@ cmd + shift - t [
   "Google Chrome" ~
   "Arc" ~
   "Safari" ~
-  * : open -na /Applications/WezTerm.app
+  "Helium" ~
+  * : open -na /Applications/Ghostty.app
 ]
+cmd + shift - return : open -na /Applications/Ghostty.app
 cmd + shift - b : open -na /Applications/Helium.app
 cmd + shift - f : open -a Finder
 cmd + shift - a : open -a ChatGPT
 
 # If you want true Omarchy, but it conflicts with send/submit in apps:
-# cmd - return : open -na /Applications/WezTerm.app
+# cmd - return : open -na /Applications/Ghostty.app
 ```
 
 Start the service and grant Accessibility permissions to `skhd`:
@@ -151,6 +153,8 @@ launchctl kickstart -k gui/$(id -u)/com.koekeishiya.skhd
 ```
 
 Notes:
+- `Cmd+Shift+T` now launches a fresh Ghostty window by default, but passes through unchanged in Chrome, Arc, Safari, and Helium so those apps can keep their tab restore behavior.
+- `Cmd+Shift+Return` is an explicit backup shortcut for opening a fresh Ghostty window.
 - The launcher uses `open -na` on purpose so new windows open in your current workspace instead of jumping to an existing app window in another macOS Space.
 - Expected tradeoff: each fresh app instance shows as its own icon in the Dock while running.
 - If you prefer single Dock app grouping, switch those bindings back to `open -a ...`, but macOS may jump to another Space.

--- a/osx/config/.skhdrc
+++ b/osx/config/.skhdrc
@@ -1,15 +1,18 @@
 # Omarchy-style app launchers on macOS.
 # Use `open -na` to force fresh app instances in the current workspace.
 # Tradeoff: each instance appears as its own Dock icon.
+# Keep tabbed apps on passthrough so Cmd+Shift+T can reopen tabs there.
 cmd + shift - t [
   "Google Chrome" ~
   "Arc" ~
   "Safari" ~
-  * : open -na /Applications/WezTerm.app
+  "Helium" ~
+  * : open -na /Applications/Ghostty.app
 ]
+cmd + shift - return : open -na /Applications/Ghostty.app
 cmd + shift - b : open -na /Applications/Helium.app
 cmd + shift - f : open -a Finder
 cmd + shift - a : open -a ChatGPT
 
 # Optional true Omarchy style:
-# cmd - return : open -na /Applications/WezTerm.app
+# cmd - return : open -na /Applications/Ghostty.app


### PR DESCRIPTION
## Summary
- switch the global Cmd+Shift+T launcher back to Ghostty
- exempt Helium from the global Cmd+Shift+T binding so its tab restore shortcut passes through
- add Cmd+Shift+Return as a backup shortcut for opening a fresh Ghostty window
- update the macOS README to match the new skhd behavior

## Testing
- verified the skhd config diff and reloaded skhd locally with `launchctl kickstart -k gui/$(id -u)/com.koekeishiya.skhd`
- no automated tests for these macOS config/docs changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default terminal application for keyboard shortcuts from WezTerm to Ghostty.
  * Added new keyboard shortcut: Cmd+Shift+B to launch Helium.
  * Added new keyboard shortcut: Cmd+Shift+Return to open a fresh Ghostty window.
  * Updated keyboard configuration and related documentation to reflect terminal application changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->