### PR TITLE
chore: share codex agents and exa config with opencode

### DIFF
--- a/linux-omarchy/.shell_secrets.template
+++ b/linux-omarchy/.shell_secrets.template
@@ -2,8 +2,8 @@
 # Copy this to ~/.shell_secrets and fill in your values
 # DO NOT commit the actual .shell_secrets file
 
-# Context7 API key (for Claude Code MCP plugin)
-export CONTEXT7_API_KEY=
+# Exa API key (for Codex/OpenCode Exa MCP)
+export EXA_API_KEY=
 
 # NordVPN SOCKS proxy credentials (optional)
 export NORDVPN_SOCKS_USER=

--- a/linux-popos/config/.shell_secrets.template
+++ b/linux-popos/config/.shell_secrets.template
@@ -5,6 +5,9 @@
 # GitHub token for MCP servers
 export GITHUB_TOKEN="your_github_token_here"
 
+# Exa API key (for Codex/OpenCode Exa MCP)
+export EXA_API_KEY="your_exa_key_here"
+
 # ElevenLabs API Key
 export ELEVENLABS_API_KEY="your_elevenlabs_key_here"
 

--- a/universal/.codex/AGENTS.md
+++ b/universal/.codex/AGENTS.md
@@ -1,34 +1,38 @@
 # Agent Guidelines
 
 ## Autonomy & Progress
+
 - Work independently to unblock yourself: research, review the codebase, and create targeted tests when useful.
-- Once I say “go”, proceed without status updates until you’re finished and there’s a PR ready for review that has been thoroughly tested.
-- Never spend time carrying open changes on `main`; fix them immediately, commit on a branch, and get them PR'd into `main`.
-- Keep `main` clean; if a PR is clean (green checks, no conflicts), use auto-merge.
+- Once I say "go", proceed without status updates until you're finished and there's a PR ready for review that has been thoroughly tested.
 
 ## Engineering Ownership (SDLC)
+
 - Own the outcome end-to-end: correctness, reliability, and maintainability.
 - Prefer clean, readable code: good structure/grouping, no dead code.
 - Make small, low-risk refactors as you go; avoid high-risk/complex refactors unless necessary.
 
 ## Quality & Testing
+
 - Reproduce defects before fixing.
 - If a test should have caught it, add/adjust tests alongside the fix (skip only for truly trivial syntax-only issues).
 
 ## Communication Norms
-- Disagree when you think I’m wrong; don’t flatter or rubber-stamp.
-- Be succinct by default; I’ll ask if I want more detail.
+
+- Disagree when you think I'm wrong; don't flatter or rubber-stamp.
+- Be succinct by default; I'll ask if I want more detail.
 
 ## Simplicity & Maintainability
-- Avoid hacks and messy code; do things “right” without adding unnecessary behavior/complexity.
+
+- Avoid hacks and messy code; do things "right" without adding unnecessary behavior/complexity.
 - If my request is overly elaborate, propose a simpler option.
-- Prefer readability: descriptive names; docstrings are fine to capture intent/“why”, not to justify existence.
-- Do not recommend solutions that add complexity for backwards compatibility unless explicitly requested. 
+- Prefer readability: descriptive names; docstrings are fine to capture intent/"why", not to justify existence.
+- Do not recommend solutions that add complexity for backwards compatibility unless explicitly requested.
 - If we pivot approaches we must deprecate the old approach completely and the cleanup shouyld be done as part of the change
 
 ## Tools
+
 - you have: gh, vercel, gcloud, convex, d3k, sentry-cli, and others installed in the cli. most projects arent public and need to be accessed with authed tools.
 
+## Memory
 
-## Branching types
-feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+- Store temporary data in repository `.memory/` directory (gitignored, but add a .ignore with !.memory/** so the agent can still view it). Create the .memory folder if it doesn't exist, do not use /tmp

--- a/universal/.codex/config.toml
+++ b/universal/.codex/config.toml
@@ -11,6 +11,11 @@ approval_policy = "never"
 hide_full_access_warning = true
 hide_rate_limit_model_nudge = true
 
+[mcp_servers.exa]
+command = "npx"
+args = ["-y", "exa-mcp-server"]
+env_vars = ["EXA_API_KEY"]
+
 [features]
 unified_exec = true
 shell_snapshot = true

--- a/universal/.opencode/AGENTS.md
+++ b/universal/.opencode/AGENTS.md
@@ -1,0 +1,1 @@
+../.codex/AGENTS.md

--- a/universal/.opencode/opencode.jsonc
+++ b/universal/.opencode/opencode.jsonc
@@ -4,6 +4,11 @@
 	"model": "anthropic/claude-opus-4-6",
 	"small_model": "anthropic/claude-haiku-4-5",
 	"mcp": {
+		"exa": {
+			"type": "local",
+			"command": ["npx", "-y", "exa-mcp-server"],
+			"enabled": true
+		},
 		"gh_grep": {
 			"type": "remote",
 			"url": "https://mcp.grep.app",


### PR DESCRIPTION
## Summary
- share one canonical global AGENTS file between Codex and OpenCode
- rename the tracked OpenCode config backup to `opencode.jsonc`
- add Exa MCP wiring and update shell secret templates to use `EXA_API_KEY`

## Verification
- confirmed `~/.codex/AGENTS.md` and `~/.config/opencode/AGENTS.md` both resolve to `universal/.codex/AGENTS.md`
- captured a real OpenCode system prompt from a separate git repo and verified it included `Instructions from: /home/anandpant/.config/opencode/AGENTS.md` plus the shared guidelines text
- ran `git diff --cached --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exa MCP server integration is now available and configured for local deployment.

* **Documentation**
  * Agent guidelines updated with memory storage best practices. Temporary data should now be stored in a gitignored `.memory/` directory rather than system temporary locations.

* **Chores**
  * Environment variable configuration updated to use Exa API key instead of the previous Context7 API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->