### PR TITLE
chore: enable exa mcp for codex

### DIFF
--- a/universal/.codex/config.toml
+++ b/universal/.codex/config.toml
@@ -17,3 +17,7 @@ shell_snapshot = true
 multi_agent = true
 steer = true
 personality = false
+
+[mcp_servers.exa]
+url = "https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa,company_research_exa,people_search_exa"
+bearer_token_env_var = "EXA_API_KEY"


### PR DESCRIPTION
## Summary
- add the Exa MCP server to the repo-managed global Codex config
- wire Exa auth to the global EXA_API_KEY env var
- keep multi-agent enabled and leave Context7 absent from Codex global config

## Verification
- Name  Url                                                                                                                                           Bearer Token Env Var  Status   Auth        
exa   https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa,company_research_exa,people_search_exa  EXA_API_KEY           enabled  Bearer token
- exa
  enabled: true
  transport: streamable_http
  url: https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa,company_research_exa,people_search_exa
  bearer_token_env_var: EXA_API_KEY
  http_headers: -
  env_http_headers: -
  remove: codex mcp remove exa
- child_agents_md                  under development  false
multi_agent                      stable             true


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new external service integration with authentication configuration, expanding available tools and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->