### PR TITLE
chore: track Gemini CLI settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,16 @@
 **/.mcp.json
 **/.claude.json
 **/.DS_Store
+**/.gemini/google_accounts.json
+**/.gemini/oauth_creds.json
+**/.gemini/installation_id
+**/.gemini/projects.json
+**/.gemini/state.json
+**/.gemini/trustedFolders.json
+**/.gemini/history/
+**/.gemini/tmp/
+**/.gemini/antigravity/
+**/.gemini/antigravity-browser-profile/
 
 # local claude settings
 .claude/settings.local.json

--- a/osx/README.md
+++ b/osx/README.md
@@ -134,14 +134,16 @@ cmd + shift - t [
   "Google Chrome" ~
   "Arc" ~
   "Safari" ~
-  * : open -na /Applications/WezTerm.app
+  "Helium" ~
+  * : open -na /Applications/Ghostty.app
 ]
+cmd + shift - return : open -na /Applications/Ghostty.app
 cmd + shift - b : open -na /Applications/Helium.app
 cmd + shift - f : open -a Finder
 cmd + shift - a : open -a ChatGPT
 
 # If you want true Omarchy, but it conflicts with send/submit in apps:
-# cmd - return : open -na /Applications/WezTerm.app
+# cmd - return : open -na /Applications/Ghostty.app
 ```
 
 Start the service and grant Accessibility permissions to `skhd`:
@@ -151,6 +153,8 @@ launchctl kickstart -k gui/$(id -u)/com.koekeishiya.skhd
 ```
 
 Notes:
+- `Cmd+Shift+T` now launches a fresh Ghostty window by default, but passes through unchanged in Chrome, Arc, Safari, and Helium so those apps can keep their tab restore behavior.
+- `Cmd+Shift+Return` is an explicit backup shortcut for opening a fresh Ghostty window.
 - The launcher uses `open -na` on purpose so new windows open in your current workspace instead of jumping to an existing app window in another macOS Space.
 - Expected tradeoff: each fresh app instance shows as its own icon in the Dock while running.
 - If you prefer single Dock app grouping, switch those bindings back to `open -a ...`, but macOS may jump to another Space.

--- a/osx/config/.skhdrc
+++ b/osx/config/.skhdrc
@@ -1,15 +1,18 @@
 # Omarchy-style app launchers on macOS.
 # Use `open -na` to force fresh app instances in the current workspace.
 # Tradeoff: each instance appears as its own Dock icon.
+# Keep tabbed apps on passthrough so Cmd+Shift+T can reopen tabs there.
 cmd + shift - t [
   "Google Chrome" ~
   "Arc" ~
   "Safari" ~
-  * : open -na /Applications/WezTerm.app
+  "Helium" ~
+  * : open -na /Applications/Ghostty.app
 ]
+cmd + shift - return : open -na /Applications/Ghostty.app
 cmd + shift - b : open -na /Applications/Helium.app
 cmd + shift - f : open -a Finder
 cmd + shift - a : open -a ChatGPT
 
 # Optional true Omarchy style:
-# cmd - return : open -na /Applications/WezTerm.app
+# cmd - return : open -na /Applications/Ghostty.app

--- a/universal/.gemini/settings.json
+++ b/universal/.gemini/settings.json
@@ -1,0 +1,5 @@
+{
+  "skills": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
## Summary
- add a tracked Gemini CLI settings file under `universal/.gemini/`
- disable Gemini skills globally via `skills.enabled: false`
- ignore local Gemini auth, history, and state files so only portable config is tracked

## Validation
- `jq empty universal/.gemini/settings.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminal launcher documentation with Ghostty as the default terminal application.
* **Configuration**
  * Added keyboard shortcut for opening terminal.
  * Disabled skills feature in application settings.
* **Chores**
  * Extended ignore list for workspace configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->