### PR TITLE
docs: add repo workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Repository Workflow
+
+This repository exists to keep working configs, scripts, and prompts reproducible across machines. Do not leave meaningful config work stranded only on the current laptop.
+
+## Git Hygiene
+
+- Avoid random stashes, local-only branches, and other local-only state hanging around after a task.
+- Avoid important files existing only locally. If a file matters, commit it and get it into the remote; otherwise delete it or add a `.gitignore` rule in the same change.
+- Prefer small, focused PRs that move real config changes into the remote quickly instead of batching unrelated local tweaks for later.
+
+## Config Sync
+
+- When copying settings from home-directory tools into this repo, commit only portable and intentional config.
+- Do not commit auth tokens, OAuth state, machine-specific caches, history, or other ephemeral local data.
+- If a useful local file should stay machine-specific, keep it out of the repo explicitly with `.gitignore`.

--- a/universal/.codex/AGENTS.md
+++ b/universal/.codex/AGENTS.md
@@ -35,10 +35,10 @@
 
 ## Git Workflow
 
-- Do not leave the repository on a local-only branch or other local variation when the task is complete unless the user explicitly asks for that.
-- Prefer a short-lived PR branch only for the duration needed to commit and open the PR. Assume owner PRs should auto-merge when the repository is configured for it.
-- After the PR is merged, switch back to `main`, pull the latest remote state, and restore any preserved local working changes so the repo ends in a clean, current base state.
-- If branch switching is blocked by unrelated local edits, preserve them safely first, complete the PR flow, then restore them after returning to `main`.
+- Avoid leaving random stashes, local-only branches, or other local-only state behind when the task is complete.
+- Avoid important files existing only on the current machine. If a file matters, commit it and get it into the remote; otherwise delete it or add an appropriate `.gitignore` rule.
+- Prefer small PRs that move real work into the remote quickly instead of letting config changes sit locally and drift.
+- If you temporarily stash or branch to get work done, clean that up before finishing unless the user explicitly asks to keep it around.
 
 ## Memory
 


### PR DESCRIPTION
## Summary
- add a root `AGENTS.md` for this repository with repo-specific workflow expectations
- soften the shared agent git guidance so it focuses on avoiding stranded local-only work
- make the repo guidance explicit about committing or ignoring local-only config files

## Why
- this repo should help keep working configs available across machines instead of leaving meaningful changes only on one laptop


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Git workflow guidance documenting repository expectations, including Git hygiene best practices and configuration synchronization rules for maintaining a clean, portable codebase.
  * Updated existing workflow documentation with refined cleanup and synchronization protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->