### PR TITLE
[codex] expand exa mcp config

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Both Bash and Zsh configurations include:
 - **System Info**: Memory (`meminfo`), CPU (`cpuinfo`), disk usage (`diskinfo`)
 - **Clipboard**: Cross-platform clipboard support (`pbcopy`, `pbpaste` via xclip)
 - **Secure Credentials**: Automatic loading from `.shell_secrets`
+- **Exa MCP**: Set `EXA_API_KEY` in `~/.shell_secrets` for Codex/OpenCode Exa support
 - **Modern CLI Tools**: eza (ls replacement), bat (cat replacement with automatic secret masking for `.env` files), ripgrep, fd
 
 ### Zsh-Specific Enhancements

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Both Bash and Zsh configurations include:
 - **System Info**: Memory (`meminfo`), CPU (`cpuinfo`), disk usage (`diskinfo`)
 - **Clipboard**: Cross-platform clipboard support (`pbcopy`, `pbpaste` via xclip)
 - **Secure Credentials**: Automatic loading from `.shell_secrets`
-- **Exa MCP**: Set `EXA_API_KEY` in `~/.shell_secrets` for Codex/OpenCode Exa support
+- **Exa MCP**: Set `EXA_API_KEY` in `~/.shell_secrets`; tracked Codex/OpenCode configs enable web search, advanced search, code context, crawling, company research, people search, and deep research
 - **Modern CLI Tools**: eza (ls replacement), bat (cat replacement with automatic secret masking for `.env` files), ripgrep, fd
 
 ### Zsh-Specific Enhancements

--- a/universal/.codex/config.toml
+++ b/universal/.codex/config.toml
@@ -13,7 +13,11 @@ hide_rate_limit_model_nudge = true
 
 [mcp_servers.exa]
 command = "npx"
-args = ["-y", "exa-mcp-server"]
+args = [
+  "-y",
+  "exa-mcp-server",
+  "tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa,company_research_exa,people_search_exa,deep_researcher_start,deep_researcher_check",
+]
 # Set EXA_API_KEY in ~/.shell_secrets (already sourced from ~/.zshrc).
 env_vars = ["EXA_API_KEY"]
 

--- a/universal/.codex/config.toml
+++ b/universal/.codex/config.toml
@@ -14,6 +14,7 @@ hide_rate_limit_model_nudge = true
 [mcp_servers.exa]
 command = "npx"
 args = ["-y", "exa-mcp-server"]
+# Set EXA_API_KEY in ~/.shell_secrets (already sourced from ~/.zshrc).
 env_vars = ["EXA_API_KEY"]
 
 [features]
@@ -22,7 +23,3 @@ shell_snapshot = true
 multi_agent = true
 steer = true
 personality = false
-
-[mcp_servers.exa]
-url = "https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa,company_research_exa,people_search_exa"
-bearer_token_env_var = "EXA_API_KEY"

--- a/universal/.opencode/opencode.jsonc
+++ b/universal/.opencode/opencode.jsonc
@@ -6,8 +6,16 @@
 	"mcp": {
 		"exa": {
 			"type": "local",
-			"command": ["npx", "-y", "exa-mcp-server"],
-			"enabled": true
+			"command": [
+				"npx",
+				"-y",
+				"exa-mcp-server",
+				"tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa,company_research_exa,people_search_exa,deep_researcher_start,deep_researcher_check"
+			],
+			"enabled": true,
+			"environment": {
+				"EXA_API_KEY": "{env:EXA_API_KEY}"
+			}
 		},
 		"gh_grep": {
 			"type": "remote",


### PR DESCRIPTION
This PR finishes the Exa MCP sync for the shared CLI configs.

The first commit fixes the invalid Codex Exa configuration shape in the repo. The tracked config had duplicate `mcp_servers.exa` tables with conflicting local and remote settings. The repo now keeps a single valid local `exa-mcp-server` entry and reads `EXA_API_KEY` from the environment instead of hardcoding credentials.

The follow-up commit expands the configured Exa tool set to the full set we actually want available in Codex and OpenCode. The tracked configs now explicitly enable web search, advanced web search, code context, crawling, company research, people search, and deep research (`deep_researcher_start` / `deep_researcher_check`). OpenCode now also passes `EXA_API_KEY` explicitly through its `environment` block so the local MCP server does not depend on implicit inheritance.

I validated the changes by parsing the updated TOML and JSON configs, checking `codex mcp list`, checking `opencode mcp list`, and launching `npx -y exa-mcp-server` with the configured `tools=...` argument to confirm the server loads the expected tool configuration. I also previously verified the provided `EXA_API_KEY` with a live Exa API request.
