### PR TITLE
restore compact terminal and Claude status indicators

### DIFF
--- a/osx/README.md
+++ b/osx/README.md
@@ -68,13 +68,22 @@ read_only = " ro"
 [git_branch]
 symbol = ""
 style = "bold purple"
-format = " on [$branch]($style)"
+format = " [$branch]($style)"
 
 [git_status]
 style = "yellow"
-format = " [$all_status$ahead_behind]($style)"
-# Keep this a simple, valid format string to avoid parse errors.
-stashed = " stash:$count"
+format = " [$staged$modified$untracked$deleted$renamed$conflicted$stashed$ahead_behind]($style)"
+staged = "+$count "
+modified = "!$count "
+untracked = "?$count "
+deleted = "x$count "
+renamed = ">$count "
+conflicted = "=$count "
+stashed = "*$count "
+ahead = "^$count "
+behind = "v$count "
+diverged = "^$ahead_count v$behind_count "
+up_to_date = ""
 
 [nodejs]
 symbol = ""
@@ -109,6 +118,35 @@ disabled = true
 [kubernetes]
 disabled = true
 ```
+
+---
+
+## 3b. Claude Code status line
+
+Keep Claude's own bottom status line compact and useful by pointing it at the tracked script in this repo:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "/Users/anandpant/scripts-prompts-config/universal/claude-statusline.sh"
+  }
+}
+```
+
+The script lives at:
+- `universal/claude-statusline.sh`
+
+It shows:
+- model
+- shortened working directory
+- git branch plus compact dirty/ahead-behind counts
+- context usage
+- Claude.ai 5-hour and 7-day usage when available
+
+Notes:
+- It caches git lookups for 5 seconds so the status line stays responsive in large repos.
+- Claude Code reads `statusLine` from `~/.claude/settings.json`.
 
 ---
 
@@ -363,6 +401,7 @@ The script creates a backup at:
 - [ ] Keep native `pbcopy/pbpaste/open`
 - [ ] Add Omarchy-style aliases/functions to `~/.zshrc`
 - [ ] Create `~/.config/starship.toml`
+- [ ] Point `~/.claude/settings.json` at `universal/claude-statusline.sh`
 - [ ] Install `skhd`, copy `~/.skhdrc`, enable Accessibility, restart service
 - [ ] Copy Ghostty config and keybindings or WezTerm config
 - [ ] Install AeroSpace + copy `~/.aerospace.toml` and enable Accessibility

--- a/osx/starship.toml
+++ b/osx/starship.toml
@@ -10,13 +10,22 @@ read_only = " ro"
 [git_branch]
 symbol = ""
 style = "bold purple"
-format = " on [$branch]($style)"
+format = " [$branch]($style)"
 
 [git_status]
 style = "yellow"
-format = " [$all_status$ahead_behind]($style)"
-# Keep this a simple, valid format string to avoid parse errors.
-stashed = " stash:$count"
+format = " [$staged$modified$untracked$deleted$renamed$conflicted$stashed$ahead_behind]($style)"
+staged = "+$count "
+modified = "!$count "
+untracked = "?$count "
+deleted = "x$count "
+renamed = ">$count "
+conflicted = "=$count "
+stashed = "*$count "
+ahead = "^$count "
+behind = "v$count "
+diverged = "^$ahead_count v$behind_count "
+up_to_date = ""
 
 [nodejs]
 symbol = ""

--- a/universal/claude-statusline.sh
+++ b/universal/claude-statusline.sh
@@ -1,0 +1,181 @@
+#!/bin/sh
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'Claude\n'
+  exit 0
+fi
+
+input=$(cat)
+tab=$(printf '\t')
+
+IFS="$tab" read -r model cwd ctx_pct five_hr seven_day <<EOF
+$(printf '%s' "$input" | jq -r '
+  [
+    .model.display_name // "Claude",
+    .workspace.current_dir // .cwd // "",
+    (.context_window.used_percentage // ""),
+    (.rate_limits.five_hour.used_percentage // ""),
+    (.rate_limits.seven_day.used_percentage // "")
+  ] | @tsv')
+EOF
+
+BLUE=$(printf '\033[0;34m')
+CYAN=$(printf '\033[0;36m')
+GREEN=$(printf '\033[0;32m')
+YELLOW=$(printf '\033[0;33m')
+RED=$(printf '\033[0;31m')
+MAGENTA=$(printf '\033[0;35m')
+DIM=$(printf '\033[0;90m')
+RESET=$(printf '\033[0m')
+
+count_lines() {
+  wc -l | tr -d ' '
+}
+
+file_mtime() {
+  stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || printf '0'
+}
+
+cache_is_stale() {
+  [ ! -f "$1" ] && return 0
+  now=$(date +%s)
+  mtime=$(file_mtime "$1")
+  [ $((now - mtime)) -gt "$2" ]
+}
+
+shorten_path() {
+  path=$1
+  [ -z "$path" ] && return 0
+
+  case "$path" in
+    "$HOME"*) path="~${path#$HOME}" ;;
+  esac
+
+  [ "$path" = "/" ] && {
+    printf '/'
+    return 0
+  }
+
+  path=${path%/}
+
+  case "$path" in
+    "~") printf '~' ;;
+    "~/"*)
+      rel=${path#~/}
+      case "$rel" in
+        */*)
+          base=${rel##*/}
+          parent=${rel%/*}
+          parent=${parent##*/}
+          printf '%s/%s' "$parent" "$base"
+          ;;
+        *)
+          printf '~/%s' "$rel"
+          ;;
+      esac
+      ;;
+    */*)
+      base=${path##*/}
+      rest=${path%/*}
+      case "$rest" in
+        */*)
+          parent=${rest##*/}
+          printf '%s/%s' "$parent" "$base"
+          ;;
+        *)
+          printf '%s/%s' "$rest" "$base"
+          ;;
+      esac
+      ;;
+    *)
+      printf '%s' "$path"
+      ;;
+  esac
+}
+
+format_pct() {
+  label=$1
+  value=$2
+
+  [ -z "$value" ] && return 0
+
+  int_value=$(printf '%.0f' "$value" 2>/dev/null || printf '0')
+  color=$GREEN
+
+  if [ "$int_value" -ge 80 ]; then
+    color=$RED
+  elif [ "$int_value" -ge 50 ]; then
+    color=$YELLOW
+  fi
+
+  printf '%s%s:%s%%%s' "$color" "$label" "$int_value" "$RESET"
+}
+
+git_branch=''
+git_ahead=0
+git_behind=0
+git_staged=0
+git_modified=0
+git_untracked=0
+git_conflicted=0
+
+if [ -n "$cwd" ] && git -C "$cwd" rev-parse --git-dir >/dev/null 2>&1; then
+  cache_root=${TMPDIR:-/tmp}/claude-statusline-git
+  cache_key=$(printf '%s' "$cwd" | cksum | awk '{print $1}')
+  cache_file=$cache_root/$cache_key
+  cache_max_age=5
+
+  mkdir -p "$cache_root"
+
+  if cache_is_stale "$cache_file" "$cache_max_age"; then
+    git_branch=$(git -C "$cwd" symbolic-ref --quiet --short HEAD 2>/dev/null \
+      || git -C "$cwd" rev-parse --short HEAD 2>/dev/null \
+      || printf '')
+
+    set -- $(git -C "$cwd" rev-list --left-right --count '@{upstream}...HEAD' 2>/dev/null || printf '0 0')
+    git_behind=${1:-0}
+    git_ahead=${2:-0}
+    git_staged=$(git -C "$cwd" diff --name-only --cached --diff-filter=ACDMRT 2>/dev/null | count_lines)
+    git_modified=$(git -C "$cwd" diff --name-only --diff-filter=ACDMRT 2>/dev/null | count_lines)
+    git_untracked=$(git -C "$cwd" ls-files --others --exclude-standard 2>/dev/null | count_lines)
+    git_conflicted=$(git -C "$cwd" diff --name-only --diff-filter=U 2>/dev/null | count_lines)
+
+    printf '%s|%s|%s|%s|%s|%s|%s\n' \
+      "$git_branch" \
+      "$git_ahead" \
+      "$git_behind" \
+      "$git_staged" \
+      "$git_modified" \
+      "$git_untracked" \
+      "$git_conflicted" > "$cache_file"
+  fi
+
+  IFS='|' read -r git_branch git_ahead git_behind git_staged git_modified git_untracked git_conflicted < "$cache_file"
+fi
+
+line=$(printf '%s%s%s' "$BLUE" "$model" "$RESET")
+
+short_cwd=$(shorten_path "$cwd")
+[ -n "$short_cwd" ] && line="$line $(printf '%s%s%s' "$CYAN" "$short_cwd" "$RESET")"
+
+if [ -n "$git_branch" ]; then
+  line="$line $(printf '%s%s%s' "$MAGENTA" "$git_branch" "$RESET")"
+
+  [ "${git_staged:-0}" -gt 0 ] && line="$line $(printf '%s+%s%s' "$GREEN" "$git_staged" "$RESET")"
+  [ "${git_modified:-0}" -gt 0 ] && line="$line $(printf '%s!%s%s' "$YELLOW" "$git_modified" "$RESET")"
+  [ "${git_untracked:-0}" -gt 0 ] && line="$line $(printf '%s?%s%s' "$DIM" "$git_untracked" "$RESET")"
+  [ "${git_conflicted:-0}" -gt 0 ] && line="$line $(printf '%s=%s%s' "$RED" "$git_conflicted" "$RESET")"
+  [ "${git_ahead:-0}" -gt 0 ] && line="$line $(printf '%s^%s%s' "$GREEN" "$git_ahead" "$RESET")"
+  [ "${git_behind:-0}" -gt 0 ] && line="$line $(printf '%sv%s%s' "$YELLOW" "$git_behind" "$RESET")"
+fi
+
+ctx_segment=$(format_pct ctx "$ctx_pct")
+[ -n "$ctx_segment" ] && line="$line $ctx_segment"
+
+five_hr_segment=$(format_pct 5h "$five_hr")
+[ -n "$five_hr_segment" ] && line="$line $five_hr_segment"
+
+seven_day_segment=$(format_pct 7d "$seven_day")
+[ -n "$seven_day_segment" ] && line="$line $seven_day_segment"
+
+printf '%b\n' "$line"


### PR DESCRIPTION
This change restores the compact status indicators that had fallen out of the terminal setup and makes the Claude Code status line reproducible from the repo instead of depending on an untracked home-directory script.

Before this change, the shell prompt technically still exposed Starship git modules, but the git segment was not optimized for quick scanning and the Claude status line logic lived only in `~/.claude/statusline-command.sh`. That meant the terminal no longer gave a space-efficient branch/status view by default, and the Claude-specific status indicator could drift or disappear across machines because the implementation was not tracked here.

The fix does three things. First, it tightens the Starship git display so branch plus dirty and sync markers stay compact and readable. Second, it adds a tracked `universal/claude-statusline.sh` script that shows the current model, shortened working directory, git branch with compact dirty and ahead/behind counts, context usage, and Claude.ai rate-limit usage when available. Third, it documents the setup in the macOS README so the repo-backed Starship config and Claude status line can be reapplied consistently.

The Claude status line script also caches git lookups for a short interval so frequent Claude UI refreshes do not repeatedly run more expensive git commands in large repositories.

Validation was done locally by checking shell syntax for the new script, rendering a Starship prompt using the tracked config, running the Claude status line with mock session JSON, and running `git diff --check` to ensure there were no whitespace or patch-format issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a status line displaying the current model, working directory, Git information, and resource usage (context window and rate limits).

* **Improvements**
  * Enhanced Git display formatting in the terminal prompt with clearer branch and status indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->