### PR TITLE
fix(git-hooks): portable commit-msg hook + attribution kill

### DIFF
--- a/universal/git-hooks/README.md
+++ b/universal/git-hooks/README.md
@@ -51,8 +51,11 @@ chmod +x .git/hooks/commit-msg
 The hook checks commit messages for:
 - References to "claude" (case-insensitive)
 - References to "anthropic" (case-insensitive)
+- References to "noreply@" (catches AI-tool co-author trailers by email)
 
 If found, it blocks the commit and displays an error message.
+
+Uses `-E` (extended regex) for portability across GNU grep (Linux) and BSD grep (macOS). The original `\|` basic-regex alternation silently fails on BSD grep, allowing commits through on macOS.
 
 ### Testing
 

--- a/universal/git-hooks/commit-msg
+++ b/universal/git-hooks/commit-msg
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # Prevent commits with Claude/Anthropic branding
-if grep -iq "claude\|anthropic" "$1"; then
+# Uses -E (extended regex) for portability across GNU grep (Linux) and BSD grep (macOS)
+if grep -iEq "claude|anthropic|noreply@" "$1"; then
     echo "Error: Commit message contains Claude/Anthropic branding"
     echo "Please remove references to Claude Code and Co-Authored-By: Claude"
     exit 1


### PR DESCRIPTION
## Summary
- Switch commit-msg hook from basic regex (`\|`) to extended regex (`-E`) — BSD grep on macOS silently ignores `\|`, making the hook a no-op on Macs
- Add `noreply@` pattern to catch AI-tool co-author trailers that don't mention tool/vendor names
- Symlinked `~/.git-hooks/commit-msg` to repo copy so edits propagate without re-copying (local-only, not in this diff)
- Set `attribution.commit` and `attribution.pr` to empty in `~/.claude/settings.json` to kill Co-Authored-By at the source (local-only, not in this diff)

## Test plan
- [ ] Verify hook blocks commits containing "anthropic" on macOS (BSD grep)
- [ ] Verify hook blocks commits with `noreply@` co-author trailers
- [ ] Verify clean commit messages still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed commit message validation regex to work consistently across different operating systems and grep implementations.

* **Documentation**
  * Updated commit message validation documentation with details on expanded validation patterns and improved cross-platform regex handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->