### PR TITLE
feat(codex): add grouped feature banner helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Both Bash and Zsh configurations include:
 - **Clipboard**: Cross-platform clipboard support (`pbcopy`, `pbpaste` via xclip)
 - **Secure Credentials**: Automatic loading from `.shell_secrets`
 - **Exa MCP**: Set `EXA_API_KEY` in `~/.shell_secrets`; tracked Codex/OpenCode configs enable web search, advanced search, code context, crawling, company research, people search, and deep research. The tracked OpenCode config now lives at `universal/.config/opencode/opencode.jsonc`
+- **Codex Feature Banner**: `universal/codex-shell-tools.sh` wraps `codex` so interactive launches can print grouped feature flags from `codex features list`
 - **Modern CLI Tools**: eza (ls replacement), bat (cat replacement with automatic secret masking for `.env` files), ripgrep, fd
 
 ### Zsh-Specific Enhancements
@@ -110,6 +111,7 @@ scripts-prompts-config/
 │       ├── configure_screenshot_shortcuts.sh
 │       └── update_packages.sh
 └── universal/                 # Cross-platform scripts, hooks, and troubleshooting playbooks
+    ├── codex-shell-tools.sh
     ├── convert_to_svg.sh
     ├── kill-dev.sh
     ├── optimize_logos.sh

--- a/universal/.codex/config.toml
+++ b/universal/.codex/config.toml
@@ -27,6 +27,9 @@ shell_snapshot = true
 multi_agent = true
 steer = true
 personality = false
+apps = false
+plugins = false
+tui_app_server = false
 
 [plugins."github@openai-curated"]
 enabled = false

--- a/universal/codex-shell-tools.sh
+++ b/universal/codex-shell-tools.sh
@@ -1,0 +1,160 @@
+# Shared shell helpers for surfacing Codex feature flags at launch.
+
+_codex_features_raw() {
+  command codex features list 2>/dev/null
+}
+
+_codex_features_subset() {
+  local pattern
+  pattern="${1:-^(codex_hooks|memories|tool_search|tool_suggest|js_repl|multi_agent|multi_agent_v2|tool_call_mcp_elicitation|shell_snapshot|unified_exec)[[:space:]]}"
+
+  _codex_features_raw | grep -E "$pattern" || true
+}
+
+_codex_features_nondefault() {
+  _codex_features_raw | awk '$2 != "stable" || $3 != "false"'
+}
+
+_codex_print_feature_table() {
+  local rows
+  rows="$1"
+
+  [ -n "$rows" ] || return 0
+
+  printf '%-30s %-18s %s\n' "FEATURE" "STAGE" "ENABLED"
+  printf '%-30s %-18s %s\n' "-------" "-----" "-------"
+  printf '%s\n' "$rows"
+}
+
+_codex_print_grouped_feature_table() {
+  local rows
+  rows="$1"
+
+  [ -n "$rows" ] || return 0
+
+  printf '%s\n' "$rows" | awk '
+    function add_row(stage, feature, enabled, row) {
+      row = sprintf("%-30s %s", feature, enabled)
+      if (group_rows[stage] != "") {
+        group_rows[stage] = group_rows[stage] "\n" row
+      } else {
+        group_rows[stage] = row
+      }
+      group_counts[stage]++
+    }
+
+    {
+      if (!match($0, /^(.*[^[:space:]])[[:space:]]+(true|false)[[:space:]]*$/, tail)) {
+        next
+      }
+
+      left = tail[1]
+      enabled = tail[2]
+
+      if (!match(left, /^([[:alnum:]_][[:alnum:]_-]*)[[:space:]]+(.+)$/, head)) {
+        next
+      }
+
+      feature = head[1]
+      stage = head[2]
+      add_row(stage, feature, enabled)
+      seen[stage] = 1
+    }
+
+    END {
+      ordered[1] = "stable"
+      ordered[2] = "experimental"
+      ordered[3] = "under development"
+      ordered[4] = "deprecated"
+      ordered[5] = "removed"
+
+      for (i = 1; i <= 5; i++) {
+        stage = ordered[i]
+        if (!(stage in seen) || !seen[stage]) {
+          continue
+        }
+
+        printf "%s (%d)\n", toupper(stage), group_counts[stage]
+        printf "%-30s %s\n", "FEATURE", "ENABLED"
+        printf "%-30s %s\n", "-------", "-------"
+        printf "%s\n\n", group_rows[stage]
+        printed[stage] = 1
+      }
+
+      for (stage in seen) {
+        if (!seen[stage] || printed[stage]) {
+          continue
+        }
+
+        printf "%s (%d)\n", toupper(stage), group_counts[stage]
+        printf "%-30s %s\n", "FEATURE", "ENABLED"
+        printf "%-30s %s\n", "-------", "-------"
+        printf "%s\n\n", group_rows[stage]
+      }
+    }
+  '
+}
+
+codex_feature_banner() {
+  local mode rows
+  mode="${1:-${CODEX_FEATURE_MODE:-all}}"
+
+  case "$mode" in
+    all)
+      rows="$(_codex_features_raw)"
+      ;;
+    hidden)
+      rows="$(_codex_features_subset '^(codex_hooks|memories)[[:space:]]')"
+      ;;
+    subset)
+      rows="$(_codex_features_subset)"
+      ;;
+    nondefault)
+      rows="$(_codex_features_nondefault)"
+      ;;
+    regex:*)
+      rows="$(_codex_features_subset "${mode#regex:}")"
+      ;;
+    *)
+      rows="$(_codex_features_subset "$mode")"
+      ;;
+  esac
+
+  _codex_print_grouped_feature_table "$rows"
+}
+
+codex_hidden_features() {
+  codex_feature_banner hidden
+}
+
+codex_nondefault_features() {
+  codex_feature_banner nondefault
+}
+
+codex_all_features() {
+  codex_feature_banner all
+}
+
+_codex_should_show_banner() {
+  case "${1-}" in
+    ""|--*|-*)
+      return 0
+      ;;
+    exec|review|login|logout|mcp|mcp-server|app-server|completion|sandbox|debug|apply|resume|fork|cloud|features|help)
+      return 1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
+codex() {
+  if [ -t 0 ] && [ -t 1 ] && [ "${CODEX_FEATURE_BANNER:-1}" = "1" ] && _codex_should_show_banner "${1-}"; then
+    printf 'Codex feature flags\n'
+    codex_feature_banner
+    printf '\n'
+  fi
+
+  command codex "$@"
+}


### PR DESCRIPTION
## Summary
- add a shared shell helper for surfacing Codex feature flags
- group feature output by stage and expose helper views for full, nondefault, and hidden flags
- disable Codex apps/plugins in the tracked config and document the banner helper in the README

## Verification
- ran `codex features list`
- ran `codex_feature_banner` in zsh and bash
- verified grouped output for full and hidden views

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature flag banner now displays grouped, human-readable status of available capabilities when running Codex interactively.
  * Three new feature flags added: `apps`, `plugins`, and `tui_app_server` (currently disabled).

* **Documentation**
  * Updated documentation to describe the new feature banner capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->