### PR TITLE
feat(linux): sync starship prompt with macos

### DIFF
--- a/linux-omarchy/REPLICATION-GUIDE.md
+++ b/linux-omarchy/REPLICATION-GUIDE.md
@@ -49,6 +49,16 @@ eval "$(starship init zsh)"
 eval "$(mise activate zsh)"
 ```
 
+### Match the macOS git prompt
+Ghostty is not the source of the branch details. The prompt comes from `starship`.
+
+Copy the tracked config to get the same compact branch and git-status display used on macOS:
+
+```bash
+mkdir -p ~/.config
+cp /home/anandpant/scripts-prompts-config/linux-omarchy/configs/starship.toml ~/.config/starship.toml
+```
+
 ### What each tool does:
 | Tool | Purpose |
 |------|---------|

--- a/linux-omarchy/configs/starship.toml
+++ b/linux-omarchy/configs/starship.toml
@@ -1,0 +1,61 @@
+format = "$directory$git_branch$git_status$nodejs$python$golang$rust$line_break$character"
+add_newline = true
+
+[directory]
+style = "bold cyan"
+truncation_length = 3
+truncation_symbol = "../"
+read_only = " ro"
+
+[git_branch]
+symbol = ""
+style = "bold purple"
+format = " [$branch]($style)"
+
+[git_status]
+style = "yellow"
+format = " [$staged$modified$untracked$deleted$renamed$conflicted$stashed$ahead_behind]($style)"
+staged = "+$count "
+modified = "!$count "
+untracked = "?$count "
+deleted = "x$count "
+renamed = ">$count "
+conflicted = "=$count "
+stashed = "*$count "
+ahead = "^$count "
+behind = "v$count "
+diverged = "^$ahead_count v$behind_count "
+up_to_date = ""
+
+[nodejs]
+symbol = ""
+style = "green"
+format = " via [$version]($style)"
+
+[python]
+symbol = ""
+style = "blue"
+format = " via [$version]($style)"
+
+[golang]
+symbol = ""
+style = "blue"
+format = " via [$version]($style)"
+
+[rust]
+symbol = ""
+style = "red"
+format = " via [$version]($style)"
+
+[character]
+success_symbol = "> "
+error_symbol = "> "
+
+[aws]
+disabled = true
+
+[gcloud]
+disabled = true
+
+[kubernetes]
+disabled = true


### PR DESCRIPTION
## Summary
- add a tracked Linux/Omarchy `starship.toml` that matches the macOS prompt style
- document that the branch details come from `starship`, not Ghostty
- document how to copy the tracked config into `~/.config/starship.toml`

## Verification
- updated the live `~/.config/starship.toml` separately on this machine
- verified prompt modules in this repo with:
  - `starship module git_branch`
  - `starship module git_status`
- confirmed the rendered status includes the mac-style compact git indicators


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for replicating macOS git prompt appearance on Linux systems
  * Includes configuration with customized git branch/status indicators, automatic language version detection, and visual success/error feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->