### PR TITLE
chore: sync codex and terminal config docs

### DIFF
--- a/linux-omarchy/REPLICATION-GUIDE.md
+++ b/linux-omarchy/REPLICATION-GUIDE.md
@@ -83,10 +83,11 @@ alias pbcopy='wl-copy'
 alias pbpaste='wl-paste'
 
 # Better ls (requires eza)
-alias ls='eza -lh --group-directories-first --icons=auto'
+ls() { env -u NO_COLOR command eza -lh --group-directories-first --icons=auto "$@"; }
 alias lsa='ls -a'
-alias lt='eza --tree --level=2 --long --icons --git'
+lt() { env -u NO_COLOR command eza --tree --level=2 --long --icons --git "$@"; }
 alias lta='lt -a'
+tree() { command tree -C "$@"; }
 
 # Better cat (requires bat)
 alias cat='bat'

--- a/osx/README.md
+++ b/osx/README.md
@@ -42,7 +42,8 @@ Notes:
 ## 2. Aliases and helpers
 
 The following Omarchy-style aliases/functions were added to `~/.zshrc`:
-- `eza`-based `ls`, `lt`, `lta`
+- `eza`-based `ls`, `lt`, `lta` that ignore inherited `NO_COLOR`
+- `tree` with `-C` for colorized output
 - `bat` for `cat` (with secret masking for env-like files)
 - `ff` (fzf preview), `..`/`...`/`....` navigation
 - git aliases (`g`, `gcm`, `gcam`, `gcad`)
@@ -175,14 +176,14 @@ cmd + shift - t [
   "Arc" ~
   "Safari" ~
   "Helium" ~
-  * : open -na /Applications/Ghostty.app
+  * : open -a /Applications/Ghostty.app
 ]
-cmd + shift - return : open -na /Applications/Ghostty.app
+cmd + shift - return : open -a /Applications/Ghostty.app
 cmd + shift - b : open -na /Applications/Helium.app
 cmd + shift - f : open -a Finder
 cmd + shift - a : open -a ChatGPT
 
-# If you want true Omarchy, but it conflicts with send/submit in apps:
+# If you want the old always-fresh Ghostty behavior:
 # cmd - return : open -na /Applications/Ghostty.app
 ```
 
@@ -193,11 +194,10 @@ launchctl kickstart -k gui/$(id -u)/com.koekeishiya.skhd
 ```
 
 Notes:
-- `Cmd+Shift+T` now launches a fresh Ghostty window by default, but passes through unchanged in Chrome, Arc, Safari, and Helium so those apps can keep their tab restore behavior.
-- `Cmd+Shift+Return` is an explicit backup shortcut for opening a fresh Ghostty window.
-- The launcher uses `open -na` on purpose so new windows open in your current workspace instead of jumping to an existing app window in another macOS Space.
-- Expected tradeoff: each fresh app instance shows as its own icon in the Dock while running.
-- If you prefer single Dock app grouping, switch those bindings back to `open -a ...`, but macOS may jump to another Space.
+- `Cmd+Shift+T` now reuses Ghostty by default, but passes through unchanged in Chrome, Arc, Safari, and Helium so those apps can keep their tab restore behavior.
+- `Cmd+Shift+Return` also reuses Ghostty instead of forcing another app instance.
+- This favors not accumulating stray Ghostty instances over keeping every launch pinned to the current macOS Space.
+- If you explicitly want the old "always fresh instance" behavior back, switch the bindings to `open -na ...`.
 
 ---
 
@@ -307,7 +307,7 @@ Reload config after edits:
 aerospace reload-config
 ```
 
-One-command sync for the backed-up macOS window-manager configs:
+One-command sync for the backed-up macOS window-manager and terminal configs:
 ```bash
 ./osx/scripts/apply_window_manager_setup.sh
 ```
@@ -317,7 +317,7 @@ Includes:
 - `Cmd+Ctrl+F` maximize the focused window without using macOS native fullscreen
 - `Alt+Shift+;`, then `r` force reset to tiled layout + flatten tree
 - `Alt+Shift+;`, then `a` explicit accordion mode (only when intended)
-- `Alt+Enter` open a fresh Ghostty app instance (`open -na`) for new workspace sessions
+- `Alt+Enter` reopen Ghostty without forcing a brand-new app instance
 - A login-time retiling pass to clean up stacked/restored windows after reboot
 
 Recommended macOS defaults for AeroSpace workflows:

--- a/osx/config/.aerospace.toml
+++ b/osx/config/.aerospace.toml
@@ -87,10 +87,8 @@ persistent-workspaces = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     # Maximize the focused window without creating a separate macOS fullscreen Space.
     cmd-ctrl-f = 'fullscreen --no-outer-gaps'
 
-    # Open a fresh Ghostty instance in the current workspace.
-    # Pair this with macOS Mission Control setting "switch to an application"
-    # disabled so macOS won't jump to another Space.
-    alt-enter = 'exec-and-forget open -na /Applications/Ghostty.app'
+    # Reuse Ghostty instead of forcing another app instance.
+    alt-enter = 'exec-and-forget open -a /Applications/Ghostty.app'
 
     # Workspaces (Omarchy-style on macOS)
     cmd-1 = 'workspace 1'

--- a/osx/config/.skhdrc
+++ b/osx/config/.skhdrc
@@ -1,18 +1,17 @@
 # Omarchy-style app launchers on macOS.
-# Use `open -na` to force fresh app instances in the current workspace.
-# Tradeoff: each instance appears as its own Dock icon.
+# Reuse the existing Ghostty app to avoid piling up fresh instances.
 # Keep tabbed apps on passthrough so Cmd+Shift+T can reopen tabs there.
 cmd + shift - t [
   "Google Chrome" ~
   "Arc" ~
   "Safari" ~
   "Helium" ~
-  * : open -na /Applications/Ghostty.app
+  * : open -a /Applications/Ghostty.app
 ]
-cmd + shift - return : open -na /Applications/Ghostty.app
+cmd + shift - return : open -a /Applications/Ghostty.app
 cmd + shift - b : open -na /Applications/Helium.app
 cmd + shift - f : open -a Finder
 cmd + shift - a : open -a ChatGPT
 
-# Optional true Omarchy style:
+# Optional "always fresh instance" style:
 # cmd - return : open -na /Applications/Ghostty.app

--- a/osx/scripts/apply_window_manager_setup.sh
+++ b/osx/scripts/apply_window_manager_setup.sh
@@ -9,6 +9,8 @@ install -m 0644 "$repo_root/osx/config/.aerospace.toml" "$HOME/.aerospace.toml"
 install -m 0644 "$repo_root/osx/config/.skhdrc" "$HOME/.skhdrc"
 mkdir -p "$HOME/.config/ghostty"
 install -m 0644 "$repo_root/osx/config/.config/ghostty/config" "$HOME/.config/ghostty/config"
+mkdir -p "$HOME/.config/wezterm"
+install -m 0644 "$repo_root/osx/config/.config/wezterm/wezterm.lua" "$HOME/.config/wezterm/wezterm.lua"
 
 "$repo_root/osx/scripts/configure_macos_defaults.sh"
 

--- a/universal/codex-shell-tools.sh
+++ b/universal/codex-shell-tools.sh
@@ -44,19 +44,21 @@ _codex_print_grouped_feature_table() {
     }
 
     {
-      if (!match($0, /^(.*[^[:space:]])[[:space:]]+(true|false)[[:space:]]*$/, tail)) {
+      if (NF < 3) {
         next
       }
 
-      left = tail[1]
-      enabled = tail[2]
-
-      if (!match(left, /^([[:alnum:]_][[:alnum:]_-]*)[[:space:]]+(.+)$/, head)) {
+      enabled = $NF
+      if (enabled != "true" && enabled != "false") {
         next
       }
 
-      feature = head[1]
-      stage = head[2]
+      feature = $1
+      stage = $2
+      for (i = 3; i < NF; i++) {
+        stage = stage " " $i
+      }
+
       add_row(stage, feature, enabled)
       seen[stage] = 1
     }


### PR DESCRIPTION
## Summary
- fix the Codex feature banner parser to work on macOS/BSD awk
- switch the macOS Ghostty launchers from always-fresh instances to app reuse and update the docs to match
- sync the window-manager setup script with the tracked WezTerm config and document color-safe ls/tree aliases

## Validation
- coderabbit review --prompt-only -t uncommitted
- bash -n osx/scripts/apply_window_manager_setup.sh
- zsh -n universal/codex-shell-tools.sh
- reviewed final diff after rebasing onto origin/main
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anand-testcompare/scripts-prompts-config/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
