### PR TITLE
chore: sync codex and ghostty theme handling

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,2 +1,5 @@
 [features]
 codex_hooks = true
+
+[tui]
+theme = "catppuccin-frappe"

--- a/osx/config/.config/ghostty/config
+++ b/osx/config/.config/ghostty/config
@@ -4,8 +4,8 @@
 font-family = "JetBrainsMono Nerd Font Mono"
 font-size = 14
 
-# Theme - using default with custom background
-# background = 1e1e1e  # Uncomment and adjust if you want a specific grey background
+# Theme
+theme = "Catppuccin Frappe"
 
 # Performance optimizations
 auto-update = off

--- a/universal/.codex/config.toml
+++ b/universal/.codex/config.toml
@@ -11,6 +11,9 @@ approval_policy = "never"
 hide_full_access_warning = true
 hide_rate_limit_model_nudge = true
 
+[tui]
+theme = "catppuccin-frappe"
+
 [mcp_servers.exa]
 command = "npx"
 args = [

--- a/universal/codex-shell-tools.sh
+++ b/universal/codex-shell-tools.sh
@@ -27,14 +27,27 @@ _codex_print_feature_table() {
 }
 
 _codex_print_grouped_feature_table() {
-  local rows
+  local rows true_color reset_color
   rows="$1"
 
   [ -n "$rows" ] || return 0
 
-  printf '%s\n' "$rows" | awk '
-    function add_row(stage, feature, enabled, row) {
-      row = sprintf("%-30s %s", feature, enabled)
+  if [ -t 1 ]; then
+    true_color=$'\033[32m'
+    reset_color=$'\033[0m'
+  else
+    true_color=""
+    reset_color=""
+  fi
+
+  printf '%s\n' "$rows" | awk -v true_color="$true_color" -v reset_color="$reset_color" '
+    function add_row(stage, feature, enabled, enabled_display, row) {
+      enabled_display = enabled
+      if (enabled == "true" && true_color != "") {
+        enabled_display = true_color enabled reset_color
+      }
+
+      row = sprintf("%-30s %s", feature, enabled_display)
       if (group_rows[stage] != "") {
         group_rows[stage] = group_rows[stage] "\n" row
       } else {


### PR DESCRIPTION
## Summary
- color enabled feature flags in `universal/codex-shell-tools.sh`
- keep the tracked Ghostty config on `Catppuccin Frappe`
- configure tracked Codex configs to use the working built-in TUI theme slug `catppuccin-frappe`

## Verification
- launched `codex --no-alt-screen` and confirmed the prior theme warning no longer appears
- ran `bash -n universal/codex-shell-tools.sh`
- ran `zsh -n universal/codex-shell-tools.sh`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anand-testcompare/scripts-prompts-config/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
