### PR TITLE
fix: use hosted Exa MCP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Both Bash and Zsh configurations include:
 - **System Info**: Memory (`meminfo`), CPU (`cpuinfo`), disk usage (`diskinfo`)
 - **Clipboard**: Cross-platform clipboard support (`pbcopy`, `pbpaste` via xclip)
 - **Secure Credentials**: Automatic loading from `.shell_secrets`
-- **Exa MCP**: Set `EXA_API_KEY` in `~/.shell_secrets`; tracked Codex/OpenCode configs enable web search, advanced search, code context, crawling, company research, people search, and deep research. The tracked OpenCode config now lives at `universal/.config/opencode/opencode.jsonc`
+- **Exa MCP**: Tracked Codex/OpenCode configs use Exa's hosted MCP endpoint and enable `web_search_exa`, `web_search_advanced_exa`, `get_code_context_exa`, and `crawling_exa`. Keep any `EXA_API_KEY` usage local-only; do not commit it into repo-managed MCP URLs. The tracked OpenCode config now lives at `universal/.config/opencode/opencode.jsonc`
 - **Codex Feature Banner**: `universal/codex-shell-tools.sh` wraps `codex` so interactive launches can print grouped feature flags from `codex features list`
 - **Modern CLI Tools**: eza (ls replacement), bat (cat replacement with automatic secret masking for `.env` files), ripgrep, fd
 

--- a/universal/.codex/config.toml
+++ b/universal/.codex/config.toml
@@ -15,14 +15,7 @@ hide_rate_limit_model_nudge = true
 theme = "catppuccin-frappe"
 
 [mcp_servers.exa]
-command = "npx"
-args = [
-  "-y",
-  "exa-mcp-server",
-  "tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa,company_research_exa,people_search_exa,deep_researcher_start,deep_researcher_check",
-]
-# Set EXA_API_KEY in ~/.shell_secrets (already sourced from ~/.zshrc).
-env_vars = ["EXA_API_KEY"]
+url = "https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa"
 
 [features]
 unified_exec = true

--- a/universal/.config/opencode/opencode.jsonc
+++ b/universal/.config/opencode/opencode.jsonc
@@ -4,17 +4,9 @@
   "small_model": "openai/gpt-5.4-mini",
   "mcp": {
     "exa": {
-      "type": "local",
-      "command": [
-        "npx",
-        "-y",
-        "exa-mcp-server",
-        "tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa,company_research_exa,people_search_exa,deep_researcher_start,deep_researcher_check"
-      ],
-      "enabled": true,
-      "environment": {
-        "EXA_API_KEY": "{env:EXA_API_KEY}"
-      }
+      "type": "remote",
+      "url": "https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa",
+      "enabled": true
     },
     "gh_grep": {
       "type": "remote",


### PR DESCRIPTION
## Summary
- switch tracked Codex config from `npx exa-mcp-server` to Exa's hosted MCP endpoint
- switch tracked OpenCode config to the same hosted remote MCP URL
- trim the tool list to Exa's currently documented hosted tools and update the README accordingly

## Root cause
The Exa MCP regression came from the Codex/OpenCode config switching from the hosted MCP URL to a local `npx exa-mcp-server` launch path in `52b4cff`. On this machine that launcher now fails before MCP initialization with `npm error code ENOVERSIONS`, which surfaces in Codex as `MCP startup incomplete (failed: exa)`.

## Verification
- `curl -sS 'https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa' -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'`
- `curl -sS 'https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa' -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' --data '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'`
- `codex mcp list`
- `codex exec --json 'Reply with OK.'`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anand-testcompare/scripts-prompts-config/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
