### PR TITLE
fix: support Python 3.9 in codex hook guard

### DIFF
--- a/.codex/hooks/commit_pr_guard.py
+++ b/.codex/hooks/commit_pr_guard.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import hashlib
 import json
 import os


### PR DESCRIPTION
## Summary
- make the repo-local Codex commit/PR guard hook compatible with Python 3.9
- keep the existing hook behavior unchanged by only postponing annotation evaluation

## Root cause
The stop hook and prompt-submit hook both execute `.codex/hooks/commit_pr_guard.py`. On this machine `python3` resolves to `/usr/bin/python3` version `3.9.6`, but the script used Python 3.10 union annotations like `str | None`, which crash at import time on 3.9 with:

```text
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

That caused Codex to report `Stop hook (failed) error: hook exited with code 1` before the guard logic could run.

## Verification
- `python3 --version` -> `Python 3.9.6`
- `python3 .codex/hooks/commit_pr_guard.py <<'EOF' ... {"hook_event_name":"Stop","cwd":"/Users/anandpant/scripts-prompts-config"} ... EOF` now returns the intended guard message and exit code `2`
- in a temporary dirty repo, `Stop` returns `2` and `UserPromptSubmit` with `"yup commit and pr"` returns `0`, confirming the approval-state flow works under Python 3.9

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anand-testcompare/scripts-prompts-config/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
