### PR TITLE
Default OMC launches to YOLO and remove legacy Gemini MCP

### DIFF
--- a/osx/README.md
+++ b/osx/README.md
@@ -184,11 +184,13 @@ Use the tracked installer when you want `omc` available globally without letting
 bash universal/install-omc-isolated.sh
 ```
 
-This does four things:
+This does six things:
 - installs the real OMC CLI package (`oh-my-claude-sisyphus`) globally
 - relinks both the active global `omc` shim and `~/.local/bin/omc` to the tracked wrapper at `universal/omc-wrapper.sh`
+- makes plain `omc` default to OMC's YOLO launch path while leaving management commands such as `omc setup` and `omc doctor` alone
 - forces `omc` to run with `CLAUDE_CONFIG_DIR=~/.claude-omc` and `OMC_STATE_DIR=~/.claude-omc/state`
 - on macOS, mirrors the existing Claude Code keychain login into the isolated OMC profile
+- removes the legacy `gemini-image-generation` MCP registry entry from `~/.claude.json`, `~/.omc/mcp-registry.json`, and `~/.codex/config.toml`
 - leaves `claude` on the normal `~/.claude` profile and configures global Git ignores from `osx/config/.config/git/ignore`
 
 Result:

--- a/universal/install-omc-isolated.sh
+++ b/universal/install-omc-isolated.sh
@@ -11,6 +11,11 @@ WRAPPER_SOURCE="$REPO_ROOT/universal/omc-wrapper.sh"
 WRAPPER_TARGET_LOCAL="$HOME/.local/bin/omc"
 NORMAL_CLAUDE_SETTINGS="$HOME/.claude/settings.json"
 ISOLATED_CLAUDE_SETTINGS="$OMC_CONFIG_DIR/settings.json"
+CLAUDE_MCP_CONFIG="$HOME/.claude.json"
+OMC_MCP_REGISTRY="$HOME/.omc/mcp-registry.json"
+OMC_MCP_REGISTRY_STATE="$HOME/.omc/state/mcp-registry-state.json"
+CODEX_CONFIG="$HOME/.codex/config.toml"
+LEGACY_GEMINI_MCP_NAME="gemini-image-generation"
 
 log() {
   printf '%s\n' "$*"
@@ -157,6 +162,74 @@ validate_settings() {
   log "Validated isolated OMC settings: $ISOLATED_CLAUDE_SETTINGS"
 }
 
+remove_legacy_gemini_image_generation() {
+  local tmp
+
+  if command -v jq >/dev/null 2>&1; then
+    if [ -f "$CLAUDE_MCP_CONFIG" ]; then
+      tmp="$(mktemp)"
+      jq --arg name "$LEGACY_GEMINI_MCP_NAME" '
+        del(.mcpServers[$name])
+        | (.. | objects | select(has("disabledMcpServers")) | .disabledMcpServers) |= map(select(. != $name))
+        | del(.. | objects | select(.disabledMcpServers? == []) | .disabledMcpServers)
+        | if (.mcpServers // null) == {} then del(.mcpServers) else . end
+      ' "$CLAUDE_MCP_CONFIG" > "$tmp"
+      if ! cmp -s "$CLAUDE_MCP_CONFIG" "$tmp"; then
+        mv "$tmp" "$CLAUDE_MCP_CONFIG"
+        log "Removed legacy MCP server from Claude config: $CLAUDE_MCP_CONFIG"
+      else
+        rm -f "$tmp"
+      fi
+    fi
+
+    if [ -f "$OMC_MCP_REGISTRY" ]; then
+      tmp="$(mktemp)"
+      jq --arg name "$LEGACY_GEMINI_MCP_NAME" 'del(.[$name])' "$OMC_MCP_REGISTRY" > "$tmp"
+      if ! cmp -s "$OMC_MCP_REGISTRY" "$tmp"; then
+        mv "$tmp" "$OMC_MCP_REGISTRY"
+        log "Removed legacy MCP server from OMC registry: $OMC_MCP_REGISTRY"
+      else
+        rm -f "$tmp"
+      fi
+    fi
+
+    if [ -f "$OMC_MCP_REGISTRY_STATE" ]; then
+      tmp="$(mktemp)"
+      jq --arg name "$LEGACY_GEMINI_MCP_NAME" '
+        .managedServers = ((.managedServers // []) | map(select(. != $name)))
+      ' "$OMC_MCP_REGISTRY_STATE" > "$tmp"
+      if ! cmp -s "$OMC_MCP_REGISTRY_STATE" "$tmp"; then
+        mv "$tmp" "$OMC_MCP_REGISTRY_STATE"
+        log "Removed legacy MCP server state: $OMC_MCP_REGISTRY_STATE"
+      else
+        rm -f "$tmp"
+      fi
+    fi
+  fi
+
+  if [ -f "$CODEX_CONFIG" ]; then
+    tmp="$(mktemp)"
+    awk -v target="[mcp_servers.${LEGACY_GEMINI_MCP_NAME}]" '
+      BEGIN { skip = 0 }
+      /^\[/ {
+        if ($0 == target) {
+          skip = 1
+          next
+        }
+        skip = 0
+      }
+      skip { next }
+      { print }
+    ' "$CODEX_CONFIG" > "$tmp"
+    if ! cmp -s "$CODEX_CONFIG" "$tmp"; then
+      mv "$tmp" "$CODEX_CONFIG"
+      log "Removed legacy MCP server from Codex config: $CODEX_CONFIG"
+    else
+      rm -f "$tmp"
+    fi
+  fi
+}
+
 main() {
   require_command claude
   require_command git
@@ -171,6 +244,7 @@ main() {
   ensure_plugin
   run_omc_setup
   merge_safe_base_settings
+  remove_legacy_gemini_image_generation
   validate_settings
 
   log "OMC isolated config root: $OMC_CONFIG_DIR"

--- a/universal/omc-wrapper.sh
+++ b/universal/omc-wrapper.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 OMC_WRAPPER_CONFIG_DIR="${OMC_WRAPPER_CONFIG_DIR:-$HOME/.claude-omc}"
 OMC_WRAPPER_STATE_DIR="${OMC_WRAPPER_STATE_DIR:-$OMC_WRAPPER_CONFIG_DIR/state}"
+OMC_WRAPPER_DEFAULT_YOLO="${OMC_WRAPPER_DEFAULT_YOLO:-1}"
 
 find_real_omc() {
   local self_path
@@ -44,6 +45,56 @@ find_real_omc() {
   return 1
 }
 
+is_falsey() {
+  local normalized
+  normalized="$(printf '%s' "${1-}" | tr '[:upper:]' '[:lower:]')"
+
+  case "$normalized" in
+    0|false|no|off)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+should_force_default_yolo() {
+  if is_falsey "$OMC_WRAPPER_DEFAULT_YOLO"; then
+    return 1
+  fi
+
+  case "${1-}" in
+    ""|launch)
+      ;;
+    -h|--help|-V|--version|version|help|setup|doctor|install|update|update-reconcile|config|config-stop-callback|config-notify-profile|info|test-prompt|interop|ask|wait|teleport|session|sessions|list|remove|search|status|daemon|detect|postinstall|hud|mission-board|team|autoresearch|ralphthon)
+      return 1
+      ;;
+  esac
+
+  local start_index=0
+  if [ "${1-}" = "launch" ]; then
+    start_index=1
+  fi
+
+  local -a args
+  args=("$@")
+  local arg
+  local index
+  for ((index = start_index; index < ${#args[@]}; index += 1)); do
+    arg="${args[index]}"
+    case "$arg" in
+      -h|--help|-V|--version|--yolo|--madmax|--dangerously-skip-permissions|--permission-mode|--approval-mode)
+        return 1
+        ;;
+      --dangerously-skip-permissions=*|--permission-mode=*|--approval-mode=*)
+        return 1
+        ;;
+    esac
+  done
+
+  return 0
+}
+
 if ! REAL_OMC_BIN="$(find_real_omc)"; then
   cat >&2 <<'EOF'
 omc wrapper could not find the real OMC CLI.
@@ -55,5 +106,9 @@ fi
 
 export CLAUDE_CONFIG_DIR="$OMC_WRAPPER_CONFIG_DIR"
 export OMC_STATE_DIR="$OMC_WRAPPER_STATE_DIR"
+
+if should_force_default_yolo "$@"; then
+  set -- "$@" --yolo
+fi
 
 exec "$REAL_OMC_BIN" "$@"


### PR DESCRIPTION
## Summary
- make the tracked `omc` wrapper default plain launch sessions to OMC's YOLO path while leaving management commands alone
- remove the legacy `gemini-image-generation` MCP entry from Claude, OMC, and Codex during isolated OMC setup
- document the new wrapper and cleanup behavior in the macOS README

## Verification
- `bash -n universal/omc-wrapper.sh && bash -n universal/install-omc-isolated.sh`
- `omc --notify false -p "Reply with exactly OMC_NOTIFY_FALSE_OK."`
- `claude -p --permission-mode default "Reply with exactly CLAUDE_NORMAL_STILL_OK."`
- `rg -n "gemini-image-generation" ~/.claude.json ~/.omc ~/.codex/config.toml`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anand-testcompare/scripts-prompts-config/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
