### PR TITLE
fix: enable tmux extended-keys

### DIFF
--- a/osx/config/.tmux.conf
+++ b/osx/config/.tmux.conf
@@ -25,6 +25,7 @@ set -g display-time 4000
 set -g status-interval 5
 set -g focus-events on
 set -g escape-time 0
+set -g extended-keys on
 set -g base-index 1
 setw -g pane-base-index 1
 set -g renumber-windows on


### PR DESCRIPTION
## Summary
- Add `set -g extended-keys on` to tmux config to fix warning about modified Enter keys not working

## Test plan
- [x] Applied locally and reloaded tmux
- [ ] Verify warning no longer appears on other machines after pulling
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anand-testcompare/scripts-prompts-config/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
