### PR TITLE
Fix terminal configs: tmux, wezterm, kitty setup + pi /exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,14 @@
 # local claude settings
 .claude/settings.local.json
 
+# Pi/OMP agent configs (templates tracked, real configs ignored)
+YT:**/.pi/agent/settings.json
+SH:**/.pi/agent/auth.json
+ZJ:**/.omp/agent/config.yml
+NS:**/.omp/agent/auth.json
+RR:**/.claude-omc/settings.json
+BK:**/.claude-omc/state.json
+
 # local agent/runtime artifacts
 .memory/
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ Both Bash and Zsh configurations include:
 - **Secure Credentials**: Automatic loading from `.shell_secrets`
 - **Claude Code**: Tracked macOS user settings disable commit/PR attribution, point the Claude status line at `universal/claude-statusline.sh`, and persist `effortLevel: "high"`; `CLAUDE_CODE_EFFORT_LEVEL=max` in shell config overrides that to max on supported models
 - **Exa MCP**: Tracked Codex/OpenCode configs use Exa's hosted MCP endpoint and enable `web_search_exa`, `web_search_advanced_exa`, `get_code_context_exa`, and `crawling_exa`. Keep any `EXA_API_KEY` usage local-only; do not commit it into repo-managed MCP URLs. The tracked OpenCode config now lives at `universal/.config/opencode/opencode.jsonc`
-- **Codex Feature Banner**: `universal/codex-shell-tools.sh` wraps `codex` so interactive launches can print grouped feature flags from `codex features list`
+- **Codex Feature Banner**: `universal/codex-shell-tools.sh` wraps `codex` so interactive launches can compare current flags against a clean-home default baseline and highlight only the drifted values
 - **Modern CLI Tools**: eza (ls replacement), bat (cat replacement with automatic secret masking for `.env` files), ripgrep, fd
+- **Pi/OMP Configuration**: Tracked templates for `~/.pi/agent/settings.json` and `~/.omp/agent/config.yml` with Fireworks AI provider support (models: `fireworks-openai/accounts/fireworks/routers/kimi-k2p5-turbo`, `fireworks-anthropic/accounts/fireworks/routers/kimi-k2p5-turbo`). Keep `FIREWORKS_API_KEY` local-only in `~/.shell_secrets`
 
 ### Zsh-Specific Enhancements
 
@@ -113,23 +114,27 @@ scripts-prompts-config/
 │       ├── configure_macos_defaults.sh
 │       ├── configure_screenshot_shortcuts.sh
 │       └── update_packages.sh
-└── universal/                 # Cross-platform scripts, hooks, and troubleshooting playbooks
-    ├── codex-shell-tools.sh
-    ├── convert_to_svg.sh
-    ├── kill-dev.sh
-    ├── optimize_logos.sh
-    ├── pi-google-code-assist-antigravity-troubleshooting.md
-    └── git-hooks/
-        ├── commit-msg
-        └── README.md
+PX:└── universal/                 # Cross-platform scripts, hooks, and agent configs
+TV:    ├── codex-shell-tools.sh
+PB:    ├── convert_to_svg.sh
+RT:    ├── kill-dev.sh
+RT:    ├── optimize_logos.sh
+PK:    ├── pi-google-code-assist-antigravity-troubleshooting.md
+JK:    ├── .pi/agent/
+QV:    │   └── settings.json.template    # Pi agent configuration template
+RM:    ├── .omp/agent/
+HQ:    │   └── config.yml.template         # OMP agent configuration template
+RT:    └── git-hooks/
+YQ:        ├── commit-msg
+BN:        └── README.md
 ```
 
 ## Security
 
 ### Best Practices
 
-1. **Never commit `.shell_secrets`, `.mcp.json`, or `.claude.json`** - The repository `.gitignore` blocks these
-2. **Use the template** - `.shell_secrets.template` shows the structure without real values
+1. **Never commit `.shell_secrets`, `.mcp.json`, `.claude.json`, or agent configs** - The repository `.gitignore` blocks these
+2. **Use templates** - `.shell_secrets.template`, `.pi/agent/settings.json.template`, and `.omp/agent/config.yml.template` show the structure without real values
 3. **Rotate exposed credentials** - Immediately rotate any accidentally exposed keys
 4. **Proper permissions** - Scripts automatically set 600 on sensitive files
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Both Bash and Zsh configurations include:
 - **Codex Feature Banner**: `universal/codex-shell-tools.sh` wraps `codex` so interactive launches can compare current flags against a clean-home default baseline and highlight only the drifted values
 - **Modern CLI Tools**: eza (ls replacement), bat (cat replacement with automatic secret masking for `.env` files), ripgrep, fd
 - **Pi/OMP Configuration**: Tracked templates for `~/.pi/agent/settings.json` and `~/.omp/agent/config.yml` with Fireworks AI provider support (models: `fireworks-openai/accounts/fireworks/routers/kimi-k2p5-turbo`, `fireworks-anthropic/accounts/fireworks/routers/kimi-k2p5-turbo`). Keep `FIREWORKS_API_KEY` local-only in `~/.shell_secrets`
+- **Pi Extensions**: `universal/.pi/agent/extensions/` tracks portable global pi extensions, including `/exit` as an alias for `/quit`
 
 ### Zsh-Specific Enhancements
 
@@ -121,7 +122,9 @@ RT:    ├── kill-dev.sh
 RT:    ├── optimize_logos.sh
 PK:    ├── pi-google-code-assist-antigravity-troubleshooting.md
 JK:    ├── .pi/agent/
-QV:    │   └── settings.json.template    # Pi agent configuration template
+QV:    │   ├── settings.json.template    # Pi agent configuration template
+EX:    │   └── extensions/
+AL:    │       └── exit-command.ts       # Adds /exit alias for quitting pi
 RM:    ├── .omp/agent/
 HQ:    │   └── config.yml.template         # OMP agent configuration template
 RT:    └── git-hooks/

--- a/linux-omarchy/.shell_secrets.template
+++ b/linux-omarchy/.shell_secrets.template
@@ -8,3 +8,6 @@ export EXA_API_KEY=
 # NordVPN SOCKS proxy credentials (optional)
 export NORDVPN_SOCKS_USER=
 export NORDVPN_SOCKS_PASS=
+
+# Fireworks AI API key (for Pi/OMP Fireworks provider)
+export FIREWORKS_API_KEY=

--- a/linux-popos/config/.shell_secrets.template
+++ b/linux-popos/config/.shell_secrets.template
@@ -16,3 +16,5 @@ export ELEVENLABS_API_KEY="your_elevenlabs_key_here"
 # export AWS_ACCESS_KEY_ID=""
 # export AWS_SECRET_ACCESS_KEY=""
 # export ANTHROPIC_API_KEY=""
+# Fireworks AI API key (for Pi/OMP Fireworks provider)
+export FIREWORKS_API_KEY="your_fireworks_key_here"

--- a/osx/README.md
+++ b/osx/README.md
@@ -328,6 +328,8 @@ Includes:
 - Vim pane movement/resizing + mouse support
 - Truecolor compatibility for Ghostty and WezTerm (`xterm-ghostty:RGB`, `wezterm:RGB`)
 - TPM plugins: sensible, resurrect, continuum
+- Mouse wheel scroll enters tmux scrollback/copy-mode inside full-screen TUIs (prevents Ghostty/tmux from turning wheel input into prompt-history navigation in Codex/Claude Code)
+- `prefix + m` toggles tmux mouse mode off temporarily for native selection/Cmd-click links
 
 Use this only if you explicitly want tmux for remote persistence or a terminal-agnostic workflow. The main macOS path in this repo is now WezTerm-native.
 

--- a/osx/config/.config/kitty/kitty.conf
+++ b/osx/config/.config/kitty/kitty.conf
@@ -1,0 +1,96 @@
+# Synced from scripts-prompts-config/osx/config/.config/kitty/kitty.conf
+
+# -----------------------------------------------------------------------------
+# Theme — muted earth palette, distinct from wezterm's Tokyo Night Storm
+# -----------------------------------------------------------------------------
+include themes/aether.conf
+
+# -----------------------------------------------------------------------------
+# Font
+# -----------------------------------------------------------------------------
+font_family      JetBrainsMono Nerd Font Mono
+bold_font        auto
+italic_font      auto
+bold_italic_font auto
+font_size        14.0
+
+# -----------------------------------------------------------------------------
+# Window appearance
+# -----------------------------------------------------------------------------
+background_opacity         0.72
+background_blur            45
+dynamic_background_opacity yes
+window_padding_width       10 12
+hide_window_decorations titlebar-only
+macos_titlebar_color background
+window_border_width  1pt
+draw_minimal_borders yes
+
+# -----------------------------------------------------------------------------
+# Tab bar
+# -----------------------------------------------------------------------------
+tab_bar_edge        bottom
+tab_bar_style       powerline
+tab_powerline_style slanted
+
+# -----------------------------------------------------------------------------
+# Layouts — splits required for vsplit/hsplit launch --location
+# -----------------------------------------------------------------------------
+enabled_layouts splits,stack
+
+# -----------------------------------------------------------------------------
+# Scrollback
+# -----------------------------------------------------------------------------
+scrollback_lines 10000
+
+# -----------------------------------------------------------------------------
+# macOS behavior
+# -----------------------------------------------------------------------------
+macos_option_as_alt             yes
+macos_quit_when_last_window_closed no
+
+# -----------------------------------------------------------------------------
+# Key bindings — Ghostty/WezTerm muscle memory
+# -----------------------------------------------------------------------------
+clear_all_shortcuts yes
+
+# Clipboard
+map cmd+c        copy_to_clipboard
+map cmd+v        paste_from_clipboard
+
+# Panes (splits) — vsplit = side-by-side, hsplit = top/bottom
+map cmd+d        launch --location=vsplit --cwd=current
+map cmd+shift+d  launch --location=hsplit --cwd=current
+map cmd+w        close_window
+
+# Pane navigation
+map cmd+alt+left   neighboring_window left
+map cmd+alt+right  neighboring_window right
+map cmd+alt+up     neighboring_window up
+map cmd+alt+down   neighboring_window down
+
+# Tabs
+map cmd+t        new_tab_with_cwd
+map cmd+shift+]  next_tab
+map cmd+shift+[  previous_tab
+
+# New OS window
+map cmd+n        new_os_window_with_cwd
+
+# Font size
+map cmd+equal    change_font_size all +1.0
+map cmd+plus     change_font_size all +1.0
+map cmd+minus    change_font_size all -1.0
+map cmd+0        change_font_size all 0
+
+# Shift+Enter sends ESC+CR for Claude Code accept behavior
+map shift+enter  send_text all \x1b\r
+
+# macOS conventions
+map cmd+q        quit
+map cmd+h        hide_macos_app
+map cmd+shift+h  hide_macos_other_apps
+map cmd+m        minimize_macos_window
+
+# Reload config in-place
+map cmd+ctrl+,   load_config_file

--- a/osx/config/.config/kitty/themes/aether.conf
+++ b/osx/config/.config/kitty/themes/aether.conf
@@ -1,0 +1,44 @@
+# vim:ft=kitty
+
+## name: Aether
+## license: MIT
+## source: ported from omarchy alacritty aether theme
+##         (scripts-prompts-config/backups/omarchy-dotfiles-20260214-111647)
+
+background           #0a100b
+foreground           #e0e5e1
+selection_background #27362f
+selection_foreground #e8ede9
+cursor               #8aab96
+cursor_text_color    #0a100b
+url_color            #9ab8ac
+
+# Tabs
+active_tab_background   #8aab96
+active_tab_foreground   #0a100b
+inactive_tab_background #1a241d
+inactive_tab_foreground #5a7a6a
+
+# Windows
+active_border_color   #8aab96
+inactive_border_color #1a241d
+
+# normal
+color0 #0a100b
+color1 #c4a89a
+color2 #8aab96
+color3 #d4cba8
+color4 #8aa8a0
+color5 #b8a8a0
+color6 #9ab8ac
+color7 #d8ddd9
+
+# bright
+color8  #5a7a6a
+color9  #d8ccc4
+color10 #a3c4af
+color11 #e5e0d4
+color12 #b4d0c0
+color13 #e0d8d2
+color14 #c4dccb
+color15 #e8ede9

--- a/osx/config/.config/wezterm/wezterm.lua
+++ b/osx/config/.config/wezterm/wezterm.lua
@@ -19,13 +19,6 @@ else
   }
 end
 
-config.unix_domains = {
-  {
-    name = "main",
-  },
-}
-config.default_gui_startup_args = { "connect", "main" }
-
 config.font = wezterm.font_with_fallback({
   "JetBrainsMono Nerd Font Mono",
   "JetBrains Mono",
@@ -45,7 +38,6 @@ config.use_fancy_tab_bar = false
 config.hide_tab_bar_if_only_one_tab = true
 config.tab_bar_at_bottom = true
 config.window_decorations = "RESIZE"
-config.macos_window_background_blur = 20
 config.native_macos_fullscreen_mode = true
 config.automatically_reload_config = true
 
@@ -104,7 +96,7 @@ config.keys = {
   {
     key = "d",
     mods = "CMD|SHIFT",
-    action = split_in_current_cwd("Down"),
+    action = split_in_current_cwd("Bottom"),
   },
   {
     key = "w",

--- a/osx/config/.tmux.conf
+++ b/osx/config/.tmux.conf
@@ -32,7 +32,10 @@ setw -g pane-base-index 1
 set -g renumber-windows on
 
 # Mouse support
-set -g mouse off
+# Keep tmux mouse mode on so Ghostty wheel events are captured by tmux
+# instead of being translated into up/down history navigation inside
+# alternate-screen TUIs like Codex/Claude Code.
+set -g mouse on
 
 # -----------------------------------------------------------------------------
 # Keybindings
@@ -41,6 +44,10 @@ set -g mouse off
 bind r source-file ~/.tmux.conf \; display "Config reloaded!"
 # Toggle mouse mode so native terminal selection/Cmd-click works when needed.
 bind m if -F '#{mouse}' 'set -g mouse off \; display "Mouse OFF: native selection + Cmd-click links"' 'set -g mouse on \; display "Mouse ON: tmux mouse mode"'
+# Enter tmux scrollback/copy-mode on wheel-up when the pane is not actively
+# handling mouse input; once in copy-mode, keep forwarding wheel events there.
+bind -n WheelUpPane if-shell -F '#{mouse_any_flag}' 'send-keys -M' 'if-shell -F "#{pane_in_mode}" "send-keys -M" "copy-mode -e"'
+bind -n WheelDownPane if-shell -F '#{pane_in_mode}' 'send-keys -M' ''
 
 # Split panes using | and -
 bind | split-window -h -c "#{pane_current_path}"

--- a/osx/config/shell-extras.zsh
+++ b/osx/config/shell-extras.zsh
@@ -4,8 +4,8 @@
 # Claude Code: always use max effort
 export CLAUDE_CODE_EFFORT_LEVEL=max
 
-# Codex: print feature flags that differ from defaults before each launch
-export CODEX_FEATURE_MODE=nondefault
+# Codex: print all feature flags before each launch; green means the value differs from the default baseline
+export CODEX_FEATURE_MODE=all
 if [[ -f "$HOME/scripts-prompts-config/universal/codex-shell-tools.sh" ]]; then
   source "$HOME/scripts-prompts-config/universal/codex-shell-tools.sh"
 fi

--- a/universal/.omp/agent/config.yml.template
+++ b/universal/.omp/agent/config.yml.template
@@ -1,0 +1,26 @@
+# Copy this file to ~/.omp/agent/config.yml and customize for your setup
+# DO NOT commit the actual config.yml file with real values to version control!
+
+lastChangelogVersion: 13.19.0
+modelRoles:
+  # Default model for general tasks
+  default: openai-codex/gpt-5.4:high
+
+  # Fast/cheap model for quick tasks
+  smol: fireworks-openai/accounts/fireworks/routers/kimi-k2p5-turbo
+
+  # High-capacity model for planning
+  plan: openai-codex/gpt-5.4:xhigh
+
+  # Alternative model for specific tasks
+  slow: opencode-go/glm-5:xhigh
+
+  # Model for commit message generation
+  commit: fireworks-anthropic/accounts/fireworks/routers/kimi-k2p5-turbo
+
+hideThinkingBlock: false
+
+skills:
+  includeSkills:
+    - agent-browser
+    - readme-maintainer

--- a/universal/.pi/agent/extensions/exit-command.ts
+++ b/universal/.pi/agent/extensions/exit-command.ts
@@ -1,0 +1,10 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+export default function exitCommand(pi: ExtensionAPI) {
+	pi.registerCommand("exit", {
+		description: "Exit pi cleanly",
+		handler: async (_args, ctx) => {
+			ctx.shutdown();
+		},
+	});
+}

--- a/universal/.pi/agent/settings.json.template
+++ b/universal/.pi/agent/settings.json.template
@@ -1,0 +1,14 @@
+{
+  "_comment": "Copy this file to ~/.pi/agent/settings.json and customize for your setup",
+  "_warning": "DO NOT commit the actual settings.json file with real values to version control!",
+  "lastChangelogVersion": "0.66.1",
+  "defaultProvider": "openai-codex",
+  "defaultModel": "gpt-5.3-codex",
+  "defaultThinkingLevel": "high",
+  "enabledModels": [],
+  "skills": [
+    "!**",
+    "+agent-browser",
+    "+readme-maintainer"
+  ]
+}

--- a/universal/codex-shell-tools.sh
+++ b/universal/codex-shell-tools.sh
@@ -4,6 +4,32 @@ _codex_features_raw() {
   command codex features list 2>/dev/null
 }
 
+_codex_default_features_raw() {
+  if [ -n "${_CODEX_DEFAULT_FEATURE_ROWS_CACHE-}" ]; then
+    printf '%s\n' "$_CODEX_DEFAULT_FEATURE_ROWS_CACHE"
+    return 0
+  fi
+
+  local cache_root tmp_home rows
+  cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/codex-feature-defaults"
+
+  mkdir -p "$cache_root" 2>/dev/null || return 0
+
+  tmp_home="$(mktemp -d "$cache_root/home.XXXXXX" 2>/dev/null)" || return 0
+  rows="$(
+    HOME="$tmp_home" \
+    XDG_CONFIG_HOME="$tmp_home/.config" \
+    XDG_CACHE_HOME="$tmp_home/.cache" \
+    command codex features list 2>/dev/null
+  )"
+  rm -rf "$tmp_home"
+
+  [ -n "$rows" ] || return 0
+
+  _CODEX_DEFAULT_FEATURE_ROWS_CACHE="$rows"
+  printf '%s\n' "$rows"
+}
+
 _codex_features_subset() {
   local pattern
   pattern="${1:-^(codex_hooks|memories|tool_search|tool_suggest|js_repl|multi_agent|multi_agent_v2|tool_call_mcp_elicitation|shell_snapshot|unified_exec)[[:space:]]}"
@@ -12,7 +38,47 @@ _codex_features_subset() {
 }
 
 _codex_features_nondefault() {
-  _codex_features_raw | awk '$2 != "stable" || $3 != "false"'
+  local default_rows current_rows
+  default_rows="$1"
+  current_rows="$(_codex_features_raw)"
+
+  [ -n "$current_rows" ] || return 0
+
+  if [ -z "$default_rows" ]; then
+    printf '%s\n' "$current_rows" | awk '$2 != "stable" || $3 != "false"'
+    return 0
+  fi
+
+  {
+    printf '%s\n' "$default_rows"
+    printf '__CURRENT__\n'
+    printf '%s\n' "$current_rows"
+  } | awk '
+    $0 == "__CURRENT__" {
+      in_current = 1
+      next
+    }
+
+    {
+      if (NF < 3) {
+        next
+      }
+
+      enabled = $NF
+      if (enabled != "true" && enabled != "false") {
+        next
+      }
+
+      if (!in_current) {
+        defaults[$1] = enabled
+        next
+      }
+
+      if (!($1 in defaults) || defaults[$1] != enabled) {
+        print $0
+      }
+    }
+  '
 }
 
 _codex_print_feature_table() {
@@ -27,24 +93,57 @@ _codex_print_feature_table() {
 }
 
 _codex_print_grouped_feature_table() {
-  local rows true_color reset_color
+  local rows default_rows diff_color reset_color
   rows="$1"
+  default_rows="$2"
 
   [ -n "$rows" ] || return 0
 
   if [ -t 1 ]; then
-    true_color=$'\033[32m'
+    diff_color=$'\033[32m'
     reset_color=$'\033[0m'
   else
-    true_color=""
+    diff_color=""
     reset_color=""
   fi
 
-  printf '%s\n' "$rows" | awk -v true_color="$true_color" -v reset_color="$reset_color" '
-    function add_row(stage, feature, enabled, enabled_display, row) {
+  {
+    printf '%s\n' "$default_rows"
+    printf '__ROWS__\n'
+    printf '%s\n' "$rows"
+  } | awk -v diff_color="$diff_color" -v reset_color="$reset_color" '
+    $0 == "__ROWS__" {
+      in_rows = 1
+      next
+    }
+
+    !in_rows {
+      if (NF < 3) {
+        next
+      }
+
+      enabled = $NF
+      if (enabled != "true" && enabled != "false") {
+        next
+      }
+
+      default_enabled[$1] = enabled
+      default_count++
+      next
+    }
+
+    function add_row(stage, feature, enabled, enabled_display, row, is_nondefault) {
       enabled_display = enabled
-      if (enabled == "true" && true_color != "") {
-        enabled_display = true_color enabled reset_color
+
+      is_nondefault = 0
+      if (default_count > 0) {
+        is_nondefault = (!(feature in default_enabled) || default_enabled[feature] != enabled)
+      } else if (enabled == "true") {
+        is_nondefault = 1
+      }
+
+      if (is_nondefault && diff_color != "") {
+        enabled_display = diff_color enabled reset_color
       }
 
       row = sprintf("%-30s %s", feature, enabled_display)
@@ -111,8 +210,9 @@ _codex_print_grouped_feature_table() {
 }
 
 codex_feature_banner() {
-  local mode rows
+  local mode rows default_rows
   mode="${1:-${CODEX_FEATURE_MODE:-all}}"
+  default_rows="$(_codex_default_features_raw)"
 
   case "$mode" in
     all)
@@ -125,7 +225,7 @@ codex_feature_banner() {
       rows="$(_codex_features_subset)"
       ;;
     nondefault)
-      rows="$(_codex_features_nondefault)"
+      rows="$(_codex_features_nondefault "$default_rows")"
       ;;
     regex:*)
       rows="$(_codex_features_subset "${mode#regex:}")"
@@ -135,7 +235,7 @@ codex_feature_banner() {
       ;;
   esac
 
-  _codex_print_grouped_feature_table "$rows"
+  _codex_print_grouped_feature_table "$rows" "$default_rows"
 }
 
 codex_hidden_features() {
@@ -166,7 +266,7 @@ _codex_should_show_banner() {
 
 codex() {
   if [ -t 0 ] && [ -t 1 ] && [ "${CODEX_FEATURE_BANNER:-1}" = "1" ] && _codex_should_show_banner "${1-}"; then
-    printf 'Codex feature flags\n'
+    printf 'Codex feature flags (green = differs from default)\n'
     codex_feature_banner
     printf '\n'
   fi


### PR DESCRIPTION
## Summary

- **tmux**: wheel scrolling + Codex feature banner fixes (from prior commits on this branch)
- **wezterm**: fix Cmd+Shift+D (invalid direction "Down" → "Bottom"), drop the `unix_domains` multiplexer layer (tmux already handles persistence), and remove `macos_window_background_blur` to cut GPU/memory pressure — a 9 GB malloc crash was captured in a DiagnosticReport and blur/mux were the most plausible suspects
- **kitty**: fresh config mirroring the Ghostty/WezTerm keybindings (cmd+d vsplit, cmd+shift+d hsplit, tabs, font size, shift+enter for ESC+CR), `dynamic_background_opacity yes` so reload can change transparency in-place, splits layout enabled, Aether theme ported from the omarchy alacritty backup (distinct from the wezterm Tokyo Night Storm)
- **pi**: `/exit` alias extension under `universal/.pi/agent/extensions/` and documented in the README layout tree

## Test plan
- [ ] Relaunch wezterm, confirm Cmd+D (side-by-side) and Cmd+Shift+D (top/bottom) both split; confirm no wezterm-mux-server process
- [ ] Fully quit + relaunch kitty (not just reload, because the original session was started without `dynamic_background_opacity`); confirm transparency + blur are visible, Aether colors render, and all keybindings match muscle memory
- [ ] Open pi, type `/exit`, confirm it exits cleanly
- [ ] Watch wezterm-gui memory in Activity Monitor across a normal session to confirm the 9 GB crash does not recur