### PR TITLE
fix: disable terminal bell notifications

### DIFF
--- a/linux-omarchy/configs/ghostty-config
+++ b/linux-omarchy/configs/ghostty-config
@@ -13,6 +13,10 @@ window-padding-y = 14
 confirm-close-surface=false
 resize-overlay = never
 gtk-toolbar-style = flat
+notify-on-command-finish = never
+desktop-notifications = false
+# Prevent bells from requesting attention or rewriting the window title.
+bell-features = no-system,no-audio,no-attention,no-title,no-border
 
 # Cursor styling
 cursor-style = "block"

--- a/osx/config/.config/ghostty/config
+++ b/osx/config/.config/ghostty/config
@@ -9,6 +9,10 @@ theme = "Catppuccin Frappe"
 
 # Performance optimizations
 auto-update = off
+notify-on-command-finish = never
+desktop-notifications = false
+# Prevent bells from requesting attention or rewriting the window title.
+bell-features = no-system,no-audio,no-attention,no-title,no-border
 
 # Mac-style keybindings
 keybind = super+a=select_all

--- a/osx/config/.tmux.conf
+++ b/osx/config/.tmux.conf
@@ -27,9 +27,15 @@ set -g focus-events on
 set -g escape-time 0
 set -g extended-keys on
 set -g extended-keys-format csi-u
+set -g bell-action none
+set -g activity-action none
+set -g visual-bell off
+set -g visual-activity off
 set -g base-index 1
 setw -g pane-base-index 1
 set -g renumber-windows on
+setw -g monitor-bell off
+setw -g monitor-activity off
 
 # Mouse support
 set -g mouse off


### PR DESCRIPTION
## Summary
- disable Ghostty command-finish and desktop notifications in macOS and Linux configs
- disable Ghostty bell features that request attention or rewrite titles
- disable tmux bell and activity notifications while keeping the new extended-key settings from main

## Testing
- `tmux -L codex-check -f osx/config/.tmux.conf start-server ; show -gv bell-action ; show -gv activity-action ; show -gv extended-keys-format ; showw -gv monitor-bell ; showw -gv monitor-activity ; kill-server`
- `ghostty +validate-config --config-file ...` exits non-zero without output in this CLI environment, so only tmux settings were directly verified here
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anand-testcompare/scripts-prompts-config/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
