### PR TITLE
feat: add repo-backed acpx skill install path

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,50 @@
+# Repo-Backed Agent Skills
+
+Use `./.agents/skills` as the source of truth for skills that should be installable from this repository.
+
+## Available Skills
+
+- `acpx`
+- `workos-agent-access`
+
+## Install From This Repo
+
+List installable skills:
+
+```bash
+npx skills add anand-testcompare/scripts-prompts-config -l
+```
+
+Install `acpx` globally for Codex:
+
+```bash
+npx skills add anand-testcompare/scripts-prompts-config \
+  --skill acpx \
+  --agent codex \
+  -g -y
+```
+
+Install `workos-agent-access` globally for Codex:
+
+```bash
+npx skills add anand-testcompare/scripts-prompts-config \
+  --skill workos-agent-access \
+  --agent codex \
+  -g -y
+```
+
+## Link From A Local Clone
+
+If you want `~/.agents/skills/<name>` to point at this checkout directly, use:
+
+```bash
+./.agents/scripts/link-skill.sh acpx
+```
+
+Link every repo-backed skill:
+
+```bash
+./.agents/scripts/link-skill.sh --all
+```
+
+The linker targets `~/.agents/skills`, which Codex already reads on this machine.

--- a/.agents/scripts/link-skill.sh
+++ b/.agents/scripts/link-skill.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./.agents/scripts/link-skill.sh <skill-name> [<skill-name> ...]
+  ./.agents/scripts/link-skill.sh --all
+
+Creates symlinks in ~/.agents/skills that point at this repository's .agents/skills entries.
+EOF
+}
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd -- "${script_dir}/../.." && pwd -P)"
+source_root="${repo_root}/.agents/skills"
+target_root="${HOME}/.agents/skills"
+
+if [ "$#" -eq 0 ]; then
+  usage >&2
+  exit 1
+fi
+
+if [ "${1}" = "--all" ]; then
+  if [ "$#" -ne 1 ]; then
+    usage >&2
+    exit 1
+  fi
+  skills=()
+  while IFS= read -r skill; do
+    skills+=("${skill}")
+  done < <(find "${source_root}" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort)
+else
+  skills=("$@")
+fi
+
+mkdir -p "${target_root}"
+
+for skill in "${skills[@]}"; do
+  source_path="${source_root}/${skill}"
+  target_path="${target_root}/${skill}"
+
+  if [ ! -d "${source_path}" ]; then
+    echo "missing repo-backed skill: ${skill}" >&2
+    exit 1
+  fi
+
+  if [ -e "${target_path}" ] && [ ! -L "${target_path}" ]; then
+    echo "refusing to replace non-symlink target: ${target_path}" >&2
+    exit 1
+  fi
+
+  rm -f "${target_path}"
+  ln -s "${source_path}" "${target_path}"
+  echo "linked ${target_path} -> ${source_path}"
+done

--- a/.agents/skills/acpx/SKILL.md
+++ b/.agents/skills/acpx/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: acpx
+description: Use acpx for persistent ACP coding-agent sessions. Prefer sessions ensure + prompt -f + polling. Avoid exec unless a true one-shot is explicitly requested.
+---
+
+# acpx
+
+## Use this when
+
+Use `acpx` when you need to:
+- launch or reuse a coding-agent session
+- send a substantial prompt from a file
+- queue follow-up work on the same session
+- poll an agent until the delegated slice is actually done
+
+## Default operating style
+
+Unless the user explicitly asks for a one-shot run:
+- use persistent sessions
+- use `sessions ensure`
+- use named sessions with `-s/--session`
+- use `prompt -f <file>`
+- poll until completion
+- do not default to `exec`
+
+## Preferred commands
+
+### Codex
+
+```bash
+acpx --approve-all --auth-policy fail codex sessions ensure --name <session>
+acpx --approve-all --auth-policy fail codex set thought_level high -s <session>
+acpx --approve-all --auth-policy fail codex set model gpt-5.4 -s <session>
+acpx --approve-all --auth-policy fail codex prompt -s <session> -f <prompt-file>
+```
+
+### Claude
+
+```bash
+acpx --approve-all --auth-policy fail claude sessions ensure --name <session>
+acpx --approve-all --auth-policy fail claude prompt -s <session> -f <prompt-file>
+```
+
+Claude preference:
+- use the user's configured default/profile for **Opus 4.7 xhigh**
+- do not guess a Claude model id unless the user explicitly asks or the exact id is known
+
+## Useful follow-ups
+
+### Queue behind active work
+
+```bash
+acpx codex prompt -s <session> --no-wait -f <prompt-file>
+```
+
+### Inspect live state
+
+```bash
+acpx codex status -s <session>
+acpx codex sessions show <session>
+acpx codex sessions history <session> --limit 20
+```
+
+Use the same shape for Claude by replacing `codex` with `claude`.
+
+### Cancel active turn
+
+```bash
+acpx codex cancel -s <session>
+acpx claude cancel -s <session>
+```
+
+### Hard reset a session
+
+```bash
+acpx codex sessions close <session>
+acpx codex sessions ensure --name <session>
+```
+
+## Polling rule
+
+Unless otherwise requested, poll the delegated session until it is actually done.
+
+Example:
+
+```bash
+python3 - <<'PY'
+import subprocess, time
+agent = "codex"
+session = "backend"
+for i in range(30):
+    print(f"== poll {i+1} ==")
+    subprocess.run(["acpx", agent, "status", "-s", session], check=False)
+    subprocess.run(["acpx", agent, "sessions", "history", session, "--limit", "10"], check=False)
+    subprocess.run(["git", "status", "--short"], check=False)
+    time.sleep(10)
+PY
+```
+
+Adjust `agent` and `session` as needed.
+
+## Output modes worth using
+
+```bash
+acpx --format text codex prompt -s <session> -f <prompt-file>
+acpx --format json codex prompt -s <session> -f <prompt-file>
+acpx --format json --json-strict codex prompt -s <session> -f <prompt-file>
+```
+
+Use `--suppress-reads` when read-file output would be noisy.
+
+## `exec`
+
+Use `exec` only for a real one-shot with no desired session reuse or polling.
+
+```bash
+acpx --format quiet codex exec "summarize this repo in 3 lines"
+```

--- a/universal/.agents/README.md
+++ b/universal/.agents/README.md
@@ -1,5 +1,9 @@
 # Universal Agent Skills
 
+This folder backs up portable home-directory agent config and skill content.
+If you want a skill to be installable from this repository via `npx skills add ...`,
+track it under repo-root `./.agents/skills` instead. See [../../.agents/README.md](../../.agents/README.md).
+
 ## Local Created/Customized Skills (Copied Here)
 
 These are maintained in this folder under `skills/`:


### PR DESCRIPTION
## Summary
- back up the tuned `acpx` skill under repo-root `.agents/skills/acpx` as the git-tracked source of truth
- make the docs installer-only: repo copy in `./.agents/skills`, installed copy in `~/.agents/skills`, no repo-to-home symlink flow
- clarify that shared installs should use `npx skills add` so Codex, OpenCode, Pi, and other `.agents` consumers pick up the same universal skill copy

## Verification
- `diff -u /Users/anandpant/.agents/skills/acpx/SKILL.md .agents/skills/acpx/SKILL.md`
- `HOME="$(mktemp -d)" npx -y skills add /Users/anandpant/scripts-prompts-config -l`
- `HOME="$(mktemp -d)" npx -y skills add /Users/anandpant/scripts-prompts-config --skill acpx -g -y`
- `HOME="$(mktemp -d)" npx -y skills add 'anand-testcompare/scripts-prompts-config#feat/acpx-skill-source-of-truth' -l`
- `HOME="$(mktemp -d)" npx -y skills add 'anand-testcompare/scripts-prompts-config#feat/acpx-skill-source-of-truth' --skill acpx -g -y`
- `npx -y skills add /Users/anandpant/scripts-prompts-config --skill acpx -g -y`

## Notes
- Installing from a GitHub source writes `.agents/.skill-lock.json`; installing from a local checkout does not.
- This machine is now using the installer-managed `~/.agents/skills/acpx` copy plus agent symlinks, but if you want `acpx` recorded in `.skill-lock.json` here too, rerun after merge with `npx skills add anand-testcompare/scripts-prompts-config --skill acpx -g -y`.
