### PR TITLE
chore: allow Monitor tool without prompts

### DIFF
--- a/osx/config/.claude/settings.json
+++ b/osx/config/.claude/settings.json
@@ -17,6 +17,7 @@
       "Glob",
       "Grep",
       "Bash",
+      "Monitor",
       "WebFetch",
       "WebSearch",
       "mcp__convex",


### PR DESCRIPTION
## Summary
- Add `Monitor` to the allow list in `osx/config/.claude/settings.json` so Monitor calls (especially long-running `while`-loop poll scripts) no longer trigger a permission prompt.

## Test plan
- [ ] Next Claude Code session: invoke a Monitor command containing a `while` loop and confirm no prompt appears.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anand-testcompare/scripts-prompts-config/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
