### PR TITLE
chore: simplify package manager security configs

### DIFF
--- a/universal/package-manager-security/README.md
+++ b/universal/package-manager-security/README.md
@@ -1,64 +1,36 @@
-# Package Manager Supply Chain Security Configs
+# Package Manager Security Configs
 
-Quick reference for hardening npm, pnpm, yarn, and bun against supply chain attacks.
+Keep it simple:
 
-## Core Principle
+- **npm**: do **not** use `min-release-age` in `~/.npmrc`
+- **pnpm**: use `pnpm-config-reference` in `~/.config/pnpm/rc`
+- **bun**: use `bunfig-toml-reference` in `~/.bunfig.toml`
+- **yarn**: use `yarnrc-yml-reference` in `~/.yarnrc.yml`
 
-Block **day-zero attacks**: Malicious packages published and removed within hours. A 1-day release age threshold would have blocked the March 2026 axios attack (published ~00:00 UTC, removed ~03:30 UTC).
+## Standard defaults
 
-## Config Files
-
-| File | Location | Package Manager |
-|------|----------|----------------|
-| `npmrc-reference` | `~/.npmrc` | npm |
-| `pnpm-config-reference` | `pnpm config set` or `~/.npmrc` | pnpm |
-| `yarnrc-yml-reference` | `~/.yarnrc.yml` | Yarn Berry (v2+) |
-| `bunfig-toml-reference` | `~/.bunfig.toml` | Bun |
-
-## Key Settings
-
-### Release Age Protection
-- **npm**: `min-release-age=1` (days)
-- **pnpm**: `minimumReleaseAge=1440` (minutes)
-- **bun**: `minimumReleaseAge = 86400` (seconds, in `[install]` section)
-- **yarn**: No release age feature (rely on script disabling)
-
-Important: npm, pnpm, and Bun use different units here. npm uses days, pnpm uses minutes, and Bun uses seconds.
-
-### Script Protection
-- **npm**: `ignore-scripts=true` (all-or-nothing, use in CI)
-- **pnpm**: `strictDepBuilds=true` + `onlyBuiltDependencies` allowlist
-- **yarn**: `enableScripts: false` (per-package re-enable via `dependenciesMeta`)
-- **bun**: `trustedDependencies` in package.json (explicit allowlist)
-
-### Additional Protections
-- **pnpm**: `blockExoticSubdeps=true` — Blocks non-registry transitive deps
-- **pnpm**: `strictDepBuilds=true` — Fails install on unreviewed scripts
-
-## Emergency Override
-
-When you need to install a just-published package from your own org:
-
-```bash
-# npm (no per-scope exclusions)
-npm install package@version --min-release-age=0
-
-# pnpm (with org in minimumReleaseAgeExclude - no action needed)
-pnpm add @yourorg/package@version
-
-# bun (no per-scope exclusions)
-# Set in project bunfig.toml: minimumReleaseAge = 0
-bun add package@version
+### pnpm
+```ini
+minimum-release-age=1440
+minimum-release-age-exclude="[\"@nyrra\", \"@openontology\", \"@openai\", \"@shpitdev\", \"@sketchi-app\"]"
+block-exotic-subdeps=true
+strict-dep-builds=true
 ```
 
-## CI Best Practices
+### bun
+```toml
+[install]
+minimumReleaseAge = 86400
+```
 
-1. **Use frozen lockfiles**: `npm ci`, `pnpm install --frozen-lockfile`, `bun install --frozen-lockfile`
-2. **Lockfiles bypass age checks** — once pinned, reinstalls work immediately
-3. **Keep strict settings in CI** — only override on dev machines for fresh installs
+### yarn
+```yaml
+enableScripts: false
+```
 
-## Reference
+## Notes
 
-- npm `min-release-age`: https://docs.npmjs.com/cli/v11/commands/npm-install
-- pnpm `minimumReleaseAge`: https://pnpm.io/settings#minimumreleaseage
-- Bun `minimumReleaseAge`: https://bun.sh/docs/runtime/bunfig
+- `pnpm` uses **minutes** for release age
+- `bun` uses **seconds** for release age
+- `npm` is **not** part of the standard persistent release-age setup anymore
+- prefer lockfiles in CI: `npm ci`, `pnpm install --frozen-lockfile`, `bun install --frozen-lockfile`

--- a/universal/package-manager-security/bunfig-toml-reference
+++ b/universal/package-manager-security/bunfig-toml-reference
@@ -1,13 +1,3 @@
-# Supply chain attack protection
-# Refuse packages published less than 1 day ago (86400 seconds)
-# Blocks day-zero attacks where malicious packages are published and quickly removed
-#
-# Installation: Copy to ~/.bunfig.toml
-#
-# To install a fresh package immediately (project-level override):
-#   Create bunfig.toml in project root:
-#   [install]
-#   minimumReleaseAge = 0
-
+# ~/.bunfig.toml
 [install]
 minimumReleaseAge = 86400

--- a/universal/package-manager-security/npmrc-reference
+++ b/universal/package-manager-security/npmrc-reference
@@ -1,18 +1,7 @@
-# Supply chain attack protection
-# Refuse packages published less than 1 day ago (npm counts in days)
-# This blocks day-zero attacks where malicious packages are published and quickly removed
+# npm
+# Do not put `min-release-age` in ~/.npmrc.
+# Current npm versions warn on it in user config.
 #
-# Installation: Copy to ~/.npmrc (merge with your existing registry/auth settings)
-#
-# IMPORTANT: npm does NOT support per-scope exclusions for min-release-age.
-# To install fresh packages from your own orgs immediately, use:
-#   npm install @yourorg/package@version --min-release-age=0
-#
-# Or temporarily disable the check:
-#   npm config set min-release-age 0
-#   npm install @yourorg/package@version
-#   npm config set min-release-age 1
-
-min-release-age=1
-ignore-scripts=false
-audit=true
+# If you want a persistent release-age gate, use:
+# - pnpm-config-reference
+# - bunfig-toml-reference

--- a/universal/package-manager-security/pnpm-config-reference
+++ b/universal/package-manager-security/pnpm-config-reference
@@ -1,19 +1,5 @@
-# Supply chain attack protection
-# Refuse packages published less than 1 day ago (1440 minutes)
-# Blocks day-zero attacks where malicious packages are published and quickly removed
-#
-# These are set via: pnpm config set <key> <value>
-# Or add to .npmrc (pnpm reads it) or pnpm-workspace.yaml
-
-# Block packages published less than 1 day ago
-minimumReleaseAge=1440
-
-# Allow your own npm orgs to bypass the age check
-# Add your orgs here to install fresh packages immediately
-minimumReleaseAgeExclude=["@nyrra", "@openontology", "@shpitdev", "@sketchi-app"]
-
-# Block transitive deps from non-registry sources (git/tarball URLs)
-blockExoticSubdeps=true
-
-# Fail install if any dependency has unreviewed build scripts
-strictDepBuilds=true
+# ~/.config/pnpm/rc
+minimum-release-age=1440
+minimum-release-age-exclude="[\"@nyrra\", \"@openontology\", \"@openai\", \"@shpitdev\", \"@sketchi-app\"]"
+block-exotic-subdeps=true
+strict-dep-builds=true

--- a/universal/package-manager-security/yarnrc-yml-reference
+++ b/universal/package-manager-security/yarnrc-yml-reference
@@ -1,14 +1,2 @@
-# Supply chain attack protection
-# Disables all lifecycle scripts globally
-# Blocks postinstall scripts that malware uses as an attack vector
-#
-# Installation: Copy to ~/.yarnrc.yml (Yarn Berry/modern versions)
-#
-# Re-enable scripts for specific packages that need them (e.g., esbuild, sharp):
-#   dependenciesMeta:
-#     esbuild:
-#       built: true
-#     sharp:
-#       built: true
-
+# ~/.yarnrc.yml
 enableScripts: false


### PR DESCRIPTION
## Summary\n- simplify the package-manager security docs down to the actual live configs\n- stop recommending npm min-release-age in ~/.npmrc\n- add @openai to the pnpm minimum-release-age exclude list in the reference config\n\n## Notes\n- npm is no longer part of the standard persistent release-age setup\n- pnpm and bun remain the recommended release-age configs\n
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anand-testcompare/scripts-prompts-config/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
