### PR TITLE
Add npm install reporting wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Both Bash and Zsh configurations include:
 - **Claude Code**: Tracked macOS user settings disable commit/PR attribution, point the Claude status line at `universal/claude-statusline.sh`, and persist `effortLevel: "high"`; `CLAUDE_CODE_EFFORT_LEVEL=max` in shell config overrides that to max on supported models
 - **Exa MCP**: Tracked Codex/OpenCode configs use Exa's hosted MCP endpoint and enable `web_search_exa`, `web_search_advanced_exa`, `get_code_context_exa`, and `crawling_exa`. Keep any `EXA_API_KEY` usage local-only; do not commit it into repo-managed MCP URLs. The tracked OpenCode config now lives at `universal/.config/opencode/opencode.jsonc`
 - **Codex Feature Banner**: `universal/codex-shell-tools.sh` wraps `codex` so interactive launches can compare current flags against a clean-home default baseline and highlight only the drifted values
+- **npm Install Report**: `universal/npm-shell-tools.sh` wraps `npm install`/`npm i`/`npm add` and reports requested vs upstream vs installed versions when policies like `min-release-age` cause silent older installs
 - **Modern CLI Tools**: eza (ls replacement), bat (cat replacement with automatic secret masking for `.env` files), ripgrep, fd
 - **Pi/OMP Configuration**: Tracked templates for `~/.pi/agent/settings.json` and `~/.omp/agent/config.yml` with Fireworks AI provider support (models: `fireworks-openai/accounts/fireworks/routers/kimi-k2p5-turbo`, `fireworks-anthropic/accounts/fireworks/routers/kimi-k2p5-turbo`). Keep `FIREWORKS_API_KEY` local-only in `~/.shell_secrets`
 - **Pi Extensions**: `universal/.pi/agent/extensions/` tracks portable global pi extensions, including `/exit` as an alias for `/quit`
@@ -117,6 +118,8 @@ scripts-prompts-config/
 │       └── update_packages.sh
 PX:└── universal/                 # Cross-platform scripts, hooks, and agent configs
 TV:    ├── codex-shell-tools.sh
+NP:    ├── npm-install-aware.mjs
+NP:    ├── npm-shell-tools.sh
 PB:    ├── convert_to_svg.sh
 RT:    ├── kill-dev.sh
 RT:    ├── optimize_logos.sh

--- a/osx/README.md
+++ b/osx/README.md
@@ -37,6 +37,21 @@ eval "$(mise activate zsh)"
 Notes:
 - Keep native `pbcopy`, `pbpaste`, and `open` on macOS (do not override).
 
+### Repo-managed shell extras
+
+To keep shared shell helpers backed up in this repo, source the tracked extras file from `~/.zshrc`:
+
+```bash
+if [[ -f "$HOME/scripts-prompts-config/osx/config/shell-extras.zsh" ]]; then
+  source "$HOME/scripts-prompts-config/osx/config/shell-extras.zsh"
+fi
+```
+
+Today that file enables:
+- `CLAUDE_CODE_EFFORT_LEVEL=max`
+- the Codex feature banner from `universal/codex-shell-tools.sh`
+- the npm install report wrapper from `universal/npm-shell-tools.sh`
+
 ---
 
 ## 2. Aliases and helpers

--- a/osx/config/shell-extras.zsh
+++ b/osx/config/shell-extras.zsh
@@ -9,3 +9,8 @@ export CODEX_FEATURE_MODE=all
 if [[ -f "$HOME/scripts-prompts-config/universal/codex-shell-tools.sh" ]]; then
   source "$HOME/scripts-prompts-config/universal/codex-shell-tools.sh"
 fi
+
+# npm: after install/add, report the real upstream latest and the version npm actually installed.
+if [[ -f "$HOME/scripts-prompts-config/universal/npm-shell-tools.sh" ]]; then
+  source "$HOME/scripts-prompts-config/universal/npm-shell-tools.sh"
+fi

--- a/universal/npm-install-aware.mjs
+++ b/universal/npm-install-aware.mjs
@@ -1,0 +1,457 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+const argv = process.argv.slice(2);
+const commandName = argv[0] ?? "";
+const ANALYZE_COMMANDS = new Set(["install", "i", "add"]);
+const DAY_MS = 24 * 60 * 60 * 1000;
+const colors = process.stdout.isTTY
+	? {
+		reset: "\u001b[0m",
+		dim: "\u001b[2m",
+		bold: "\u001b[1m",
+		cyan: "\u001b[36m",
+		green: "\u001b[32m",
+		yellow: "\u001b[33m",
+		red: "\u001b[31m",
+	}
+	: {
+		reset: "",
+		dim: "",
+		bold: "",
+		cyan: "",
+		green: "",
+		yellow: "",
+		red: "",
+	};
+
+function runNpm(args) {
+	const result = spawnSync("npm", args, {
+		stdio: "inherit",
+		env: { ...process.env, NPM_INSTALL_REPORT_BYPASS: "1" },
+	});
+
+	if (result.error) {
+		console.error(`npm wrapper failed to launch npm: ${result.error.message}`);
+		return 1;
+	}
+
+	if (typeof result.status === "number") {
+		return result.status;
+	}
+
+	return 1;
+}
+
+function runNpmJson(args) {
+	const result = spawnSync("npm", args, {
+		encoding: "utf8",
+		env: { ...process.env, NPM_INSTALL_REPORT_BYPASS: "1" },
+	});
+
+	return {
+		status: typeof result.status === "number" ? result.status : 1,
+		stdout: result.stdout ?? "",
+		stderr: result.stderr ?? "",
+		error: result.error,
+	};
+}
+
+function parseInstallArgs(args) {
+	const global = args.some((arg) => arg === "-g" || arg === "--global" || arg === "--location=global");
+	const rest = args.slice(1);
+	const specs = [];
+	let expectValueFor = false;
+
+	const flagsWithValue = new Set([
+		"--access",
+		"--auth-type",
+		"--before",
+		"--cache",
+		"--cafile",
+		"--call",
+		"--cidr",
+		"--fetch-retries",
+		"--fetch-retry-factor",
+		"--fetch-retry-maxtimeout",
+		"--fetch-retry-mintimeout",
+		"--https-proxy",
+		"--include",
+		"--install-links",
+		"--install-strategy",
+		"--location",
+		"--min-release-age",
+		"--noproxy",
+		"--omit",
+		"--otp",
+		"--prefer-dedupe",
+		"--prefix",
+		"--proxy",
+		"--registry",
+		"--save-prefix",
+		"--scope",
+		"--script-shell",
+		"--tag",
+		"--userconfig",
+		"--workspace",
+		"-C",
+		"-w",
+	]);
+
+	for (let i = 0; i < rest.length; i += 1) {
+		const token = rest[i];
+		if (!token) continue;
+
+		if (expectValueFor) {
+			expectValueFor = false;
+			continue;
+		}
+
+		if (token === "--") {
+			specs.push(...rest.slice(i + 1));
+			break;
+		}
+
+		if (token.startsWith("--")) {
+			if (token.includes("=")) continue;
+			if (flagsWithValue.has(token)) {
+				expectValueFor = true;
+			}
+			continue;
+		}
+
+		if (token.startsWith("-") && token !== "-") {
+			if (token === "-g") continue;
+			if (flagsWithValue.has(token)) {
+				expectValueFor = true;
+			}
+			continue;
+		}
+
+		specs.push(token);
+	}
+
+	return { global, specs };
+}
+
+function isLocalOrNonRegistrySpec(spec) {
+	return /^(?:\.{1,2}\/|\/|~\/|file:|link:|workspace:|https?:|git\+|git:|github:|ssh:|npm:)/.test(spec);
+}
+
+function parsePackageSpec(spec) {
+	if (!spec || isLocalOrNonRegistrySpec(spec)) {
+		return {
+			raw: spec,
+			name: null,
+			requestKind: "non-registry",
+			selector: null,
+		};
+	}
+
+	if (spec.startsWith("@")) {
+		const secondSlash = spec.indexOf("/", 1);
+		if (secondSlash === -1) {
+			return { raw: spec, name: null, requestKind: "unknown", selector: null };
+		}
+		const versionAt = spec.indexOf("@", secondSlash + 1);
+		const name = versionAt === -1 ? spec : spec.slice(0, versionAt);
+		const selector = versionAt === -1 ? null : spec.slice(versionAt + 1);
+		if (selector?.startsWith("npm:")) {
+			return { raw: spec, name: null, requestKind: "alias", selector };
+		}
+		return {
+			raw: spec,
+			name,
+			requestKind: classifySelector(selector),
+			selector,
+		};
+	}
+
+	const versionAt = spec.indexOf("@");
+	const name = versionAt === -1 ? spec : spec.slice(0, versionAt);
+	const selector = versionAt === -1 ? null : spec.slice(versionAt + 1);
+	if (!name || selector?.startsWith("npm:")) {
+		return { raw: spec, name: null, requestKind: "alias", selector };
+	}
+	return {
+		raw: spec,
+		name,
+		requestKind: classifySelector(selector),
+		selector,
+	};
+}
+
+function classifySelector(selector) {
+	if (!selector) return "implicit-latest";
+	if (selector === "latest") return "latest-tag";
+	return "explicit-selector";
+}
+
+function getConfigPath(key) {
+	const result = runNpmJson(["config", "get", key]);
+	if (result.error) return null;
+	const value = result.stdout.trim();
+	if (!value || value === "null" || value === "undefined") return null;
+	return value;
+}
+
+function readMinReleaseAgeFromNpmrc(configPath) {
+	if (!configPath || !fs.existsSync(configPath)) return null;
+
+	try {
+		const content = fs.readFileSync(configPath, "utf8");
+		let value = null;
+		for (const rawLine of content.split(/\r?\n/)) {
+			const line = rawLine.replace(/^[\t ]+|[\t ]+$/g, "");
+			if (!line || line.startsWith("#") || line.startsWith(";")) continue;
+			const match = line.match(/^min-release-age\s*=\s*(.+)$/);
+			if (!match) continue;
+			const parsed = Number(match[1].trim());
+			if (Number.isFinite(parsed)) {
+				value = parsed;
+			}
+		}
+		return value && value > 0 ? value : null;
+	} catch {
+		return null;
+	}
+}
+
+function detectMinReleaseAgeFromFiles() {
+	const configPaths = [getConfigPath("globalconfig"), getConfigPath("userconfig"), path.join(process.cwd(), ".npmrc")];
+	let detected = null;
+	for (const configPath of configPaths) {
+		const value = readMinReleaseAgeFromNpmrc(configPath);
+		if (value) detected = value;
+	}
+	return detected;
+}
+
+function getReleaseAgePolicy() {
+	const minReleaseAgeResult = runNpmJson(["config", "get", "min-release-age"]);
+	if (!minReleaseAgeResult.error) {
+		const raw = minReleaseAgeResult.stdout.trim();
+		const value = Number(raw);
+		if (raw && raw !== "null" && raw !== "undefined" && Number.isFinite(value) && value > 0) {
+			return {
+				kind: "min-release-age",
+				windowDays: value,
+				label: `min-release-age=${value}`,
+				hint: "--min-release-age=0",
+			};
+		}
+	}
+
+	const configuredMinReleaseAge = detectMinReleaseAgeFromFiles();
+	if (configuredMinReleaseAge) {
+		return {
+			kind: "min-release-age",
+			windowDays: configuredMinReleaseAge,
+			label: `min-release-age=${configuredMinReleaseAge}`,
+			hint: "--min-release-age=0",
+		};
+	}
+
+	const beforeResult = runNpmJson(["config", "get", "before"]);
+	if (beforeResult.error) return null;
+	const beforeRaw = beforeResult.stdout.trim();
+	if (!beforeRaw || beforeRaw === "null" || beforeRaw === "undefined") return null;
+	const beforeTime = new Date(beforeRaw).getTime();
+	if (!Number.isFinite(beforeTime)) return null;
+	const windowDays = (Date.now() - beforeTime) / DAY_MS;
+	if (!Number.isFinite(windowDays) || windowDays <= 0) return null;
+	return {
+		kind: "before",
+		windowDays,
+		label: `before=${beforeRaw}`,
+		hint: null,
+	};
+}
+
+function getInstalledVersions(names, globalInstall) {
+	if (names.length === 0) return new Map();
+	const args = ["ls", "--depth=0", "--json"];
+	if (globalInstall) args.push("-g");
+	args.push(...names);
+
+	const result = runNpmJson(args);
+	if (!result.stdout.trim()) return new Map();
+
+	try {
+		const data = JSON.parse(result.stdout);
+		const deps = data?.dependencies ?? {};
+		return new Map(names.map((name) => [name, deps?.[name]?.version ?? null]));
+	} catch {
+		return new Map();
+	}
+}
+
+function getUpstreamMetadata(name) {
+	const result = runNpmJson(["view", name, "version", "time", "--json"]);
+	if (!result.stdout.trim()) {
+		return { latestVersion: null, latestPublishedAt: null };
+	}
+
+	try {
+		const data = JSON.parse(result.stdout);
+		const latestVersion = typeof data?.version === "string" ? data.version : null;
+		const latestPublishedAt = latestVersion && data?.time ? data.time[latestVersion] ?? null : null;
+		return { latestVersion, latestPublishedAt };
+	} catch {
+		return { latestVersion: null, latestPublishedAt: null };
+	}
+}
+
+function formatAge(ageMs) {
+	if (!Number.isFinite(ageMs) || ageMs < 0) return null;
+	const totalHours = Math.floor(ageMs / (60 * 60 * 1000));
+	if (totalHours < 1) {
+		const minutes = Math.max(1, Math.floor(ageMs / (60 * 1000)));
+		return `${minutes}m old`;
+	}
+	if (totalHours < 48) return `${totalHours}h old`;
+	const days = Math.floor(totalHours / 24);
+	return `${days}d old`;
+}
+
+function buildNote(pkg, installedVersion, upstream, releaseAgePolicy) {
+	if (!pkg.name) {
+		return { text: "skipped non-registry/path spec", color: colors.dim };
+	}
+
+	if (!installedVersion) {
+		return { text: "not present after install", color: colors.red };
+	}
+
+	if (!upstream.latestVersion) {
+		return { text: "could not read upstream latest", color: colors.yellow };
+	}
+
+	if (installedVersion === upstream.latestVersion) {
+		return { text: "matches upstream latest", color: colors.green };
+	}
+
+	if (pkg.requestKind === "explicit-selector") {
+		return {
+			text: `requested ${pkg.selector}`,
+			color: colors.cyan,
+		};
+	}
+
+	if (releaseAgePolicy && upstream.latestPublishedAt) {
+		const latestAgeMs = Date.now() - new Date(upstream.latestPublishedAt).getTime();
+		if (latestAgeMs >= 0 && latestAgeMs < releaseAgePolicy.windowDays * DAY_MS) {
+			const ageLabel = formatAge(latestAgeMs);
+			const cutoffLabel = formatAge(releaseAgePolicy.windowDays * DAY_MS) ?? `${releaseAgePolicy.windowDays.toFixed(1)}d cutoff`;
+			return {
+				text: `blocked by release-age policy${releaseAgePolicy.label ? ` [${releaseAgePolicy.label}]` : ""}${ageLabel ? ` (${ageLabel}; cutoff ${cutoffLabel})` : ""}`,
+				color: colors.yellow,
+			};
+		}
+	}
+
+	if (pkg.requestKind === "latest-tag") {
+		return { text: "requested @latest but installed older", color: colors.yellow };
+	}
+
+	return { text: "installed differs from upstream latest", color: colors.yellow };
+}
+
+function printSummary(rows, meta) {
+	if (rows.length === 0) return;
+
+	const packageWidth = Math.max("PACKAGE".length, ...rows.map((row) => row.package.length));
+	const requestedWidth = Math.max("REQUESTED".length, ...rows.map((row) => row.requested.length));
+	const upstreamWidth = Math.max("UPSTREAM".length, ...rows.map((row) => row.upstream.length));
+	const installedWidth = Math.max("INSTALLED".length, ...rows.map((row) => row.installed.length));
+
+	const pad = (value, width) => value.padEnd(width, " ");
+	const header = [
+		pad("PACKAGE", packageWidth),
+		pad("REQUESTED", requestedWidth),
+		pad("UPSTREAM", upstreamWidth),
+		pad("INSTALLED", installedWidth),
+		"NOTE",
+	].join("  ");
+
+	const scope = meta.globalInstall ? "global" : "local";
+	console.error(`\n${colors.bold}npm install report${colors.reset} ${colors.dim}(${scope})${colors.reset}`);
+	console.error(header);
+	console.error(`${colors.dim}${"-".repeat(header.length)}${colors.reset}`);
+
+	for (const row of rows) {
+		const note = `${row.note.color}${row.note.text}${colors.reset}`;
+		console.error(
+			[
+				pad(row.package, packageWidth),
+				pad(row.requested, requestedWidth),
+				pad(row.upstream, upstreamWidth),
+				pad(row.installed, installedWidth),
+				note,
+			].join("  "),
+		);
+	}
+
+	if (meta.blockedRows.length > 0) {
+		const policyHint = meta.releaseAgePolicy?.hint
+			? ` rerun with ${colors.bold}${meta.releaseAgePolicy.hint}${colors.reset} for just that install,`
+			: " inspect your npm release-age policy settings, or";
+		console.error(
+			`${colors.yellow}Hint:${colors.reset}${policyHint} or wait until the upstream release ages past your npm policy.`,
+		);
+	}
+}
+
+if (!ANALYZE_COMMANDS.has(commandName)) {
+	process.exit(runNpm(argv));
+}
+
+const parsedArgs = parseInstallArgs(argv);
+const parsedPackages = parsedArgs.specs.map(parsePackageSpec);
+const uniquePackages = [];
+const seenNames = new Set();
+
+for (const pkg of parsedPackages) {
+	if (!pkg.name) {
+		uniquePackages.push(pkg);
+		continue;
+	}
+	if (seenNames.has(pkg.name)) continue;
+	seenNames.add(pkg.name);
+	uniquePackages.push(pkg);
+}
+
+const exitCode = runNpm(argv);
+
+if (parsedArgs.specs.length === 0) {
+	process.exit(exitCode);
+}
+
+const registryPackages = uniquePackages.filter((pkg) => pkg.name);
+const installedVersions = getInstalledVersions(
+	registryPackages.map((pkg) => pkg.name),
+	parsedArgs.global,
+);
+const releaseAgePolicy = getReleaseAgePolicy();
+
+const rows = uniquePackages.map((pkg) => {
+	const upstream = pkg.name ? getUpstreamMetadata(pkg.name) : { latestVersion: null, latestPublishedAt: null };
+	const installedVersion = pkg.name ? installedVersions.get(pkg.name) ?? null : null;
+	const note = buildNote(pkg, installedVersion, upstream, releaseAgePolicy);
+	return {
+		package: pkg.name ?? pkg.raw,
+		requested: pkg.raw,
+		upstream: upstream.latestVersion ?? "-",
+		installed: installedVersion ?? "-",
+		note,
+	};
+});
+
+const blockedRows = rows.filter((row) => row.note.text.startsWith("blocked by release-age policy"));
+printSummary(rows, { globalInstall: parsedArgs.global, blockedRows, releaseAgePolicy });
+
+process.exit(exitCode);

--- a/universal/npm-shell-tools.sh
+++ b/universal/npm-shell-tools.sh
@@ -1,0 +1,35 @@
+# Shared npm helpers.
+# Wraps npm install/add so successful installs still report the real upstream latest
+# and the version npm actually installed after policies like min-release-age apply.
+
+npm_real() {
+  command npm "$@"
+}
+
+_npm_install_report_enabled() {
+  case "${NPM_INSTALL_REPORT:-1}" in
+    0|false|FALSE|no|NO)
+      return 1
+      ;;
+  esac
+
+  command -v node >/dev/null 2>&1 || return 1
+  [ -f "$HOME/scripts-prompts-config/universal/npm-install-aware.mjs" ] || return 1
+  return 0
+}
+
+npm() {
+  if [ -n "${NPM_INSTALL_REPORT_BYPASS-}" ] || ! _npm_install_report_enabled; then
+    command npm "$@"
+    return $?
+  fi
+
+  case "${1-}" in
+    install|i|add)
+      command node "$HOME/scripts-prompts-config/universal/npm-install-aware.mjs" "$@"
+      ;;
+    *)
+      command npm "$@"
+      ;;
+  esac
+}


### PR DESCRIPTION
## Summary
- add an npm wrapper that reports requested vs upstream vs installed versions after `npm install`/`npm i`/`npm add`
- surface when `min-release-age` or related release-age policy causes npm to install an older version without saying so
- document the repo-managed shell extras hook for macOS zsh

## Testing
- `bash -n universal/npm-shell-tools.sh`
- `zsh -n universal/npm-shell-tools.sh`
- `node --check universal/npm-install-aware.mjs`
- `zsh -lc 'source ~/.zshrc >/dev/null; npm install -g @mariozechner/pi-coding-agent@latest'`
- `zsh -lc 'source ~/.zshrc >/dev/null; npm install --silent left-pad@latest'`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anand-testcompare/scripts-prompts-config/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
