### PR TITLE
docs: harden WorkOS AuthKit skills

### DIFF
--- a/.agents/skills/workos-agent-access/SKILL.md
+++ b/.agents/skills/workos-agent-access/SKILL.md
@@ -17,15 +17,14 @@ Use this skill for lower-environment access only.
 
 ## Repo Clues
 
-For Prismantix Studio, confirm the current auth shape in:
+Confirm the current auth shape before choosing a login path. Common files:
 
-- `apps/studio/src/start.ts`
-- `apps/studio/src/routes/sign-in.tsx`
-- `apps/studio/src/routes/callback.tsx`
-- `convex.json`
-- `.github/workflows/studio-deploy.yml`
+- SvelteKit: `src/hooks.server.ts`, `src/routes/sign-in`, `src/routes/callback`, `src/routes/sign-out`
+- Next.js: `proxy.ts`, `middleware.ts`, `app/callback/route.ts`, `app/sign-out/route.ts`
+- Convex: `convex.json`, `convex/auth.config.ts`
+- Deploy: `.depot/workflows/*.yml`, `.github/workflows/*.yml`, app deploy scripts
 
-Today this repo uses WorkOS hosted AuthKit plus `@workos/authkit-session`, so both of these login paths are valid:
+When a repo uses WorkOS hosted AuthKit plus `@workos/authkit-session` or `@workos/authkit-sveltekit`, both of these login paths may be valid:
 
 1. real browser sign-in with persisted browser state
 2. direct sealed-session cookie injection
@@ -33,14 +32,20 @@ Today this repo uses WorkOS hosted AuthKit plus `@workos/authkit-session`, so bo
 ## Workflow
 
 1. Read `references/playbook.md`.
-2. Prefer the existing Convex `authKit` automation to configure redirect URIs, homepage URL, and CORS origins. Only reach for direct WorkOS CLI config when you are working outside the normal Convex dev or deploy path.
-3. Ensure the target WorkOS environment is selected and the app origin is configured.
-4. Provision or update the lower-env agent user with `scripts/provision-workos-user.mjs`.
-5. Choose a login path:
+2. Prefer the repo's existing Convex/AuthKit deployment contract. Do not assume Convex `authKit` automation is always safe for every environment:
+   - Dev/simple lower envs can usually auto-provision.
+   - Preview auto-provisioning can create one WorkOS env per preview deployment.
+   - Production deploys that use deployment-specific Convex deploy keys may require a pre-existing Convex WorkOS integration/env vars before `convex deploy` can configure AuthKit.
+   - A Convex "Shared AuthKit Environment" is distinct from an ad hoc WorkOS CLI environment.
+3. Only reach for direct WorkOS CLI config when you are working outside the normal Convex dev/deploy path or the deploy handoff intentionally configures WorkOS from Convex-stored credentials.
+4. Ensure the target WorkOS environment is selected and the app origin is configured.
+5. Provision or update the lower-env agent user with `scripts/provision-workos-user.mjs`.
+6. Choose a login path:
    - If the app uses `@workos/authkit-session` and you have the cookie password, prefer the sealed-session path with `scripts/issue-sealed-session.mjs`.
    - Otherwise use the hosted `/sign-in` flow and persist the browser session with `agent-browser`.
-6. Store transient credentials and session state in `.memory/workos-agent-access/`.
-7. Validate the authenticated app route you actually need, not just the homepage.
+7. Store transient credentials and session state in `.memory/workos-agent-access/`.
+8. Validate the authenticated app route you actually need, not just the homepage.
+9. If social sign-in is enabled in dev/test, do not hide or bypass it to paper over errors. Hosted social providers should reach the provider page; immediate Google/Microsoft/GitHub errors usually indicate WorkOS environment/config drift.
 
 ## Default Preference Order
 

--- a/.agents/skills/workos-agent-access/references/playbook.md
+++ b/.agents/skills/workos-agent-access/references/playbook.md
@@ -16,6 +16,10 @@ This playbook is intentionally lower-env focused. The goal is to give the agent 
   - add redirect URIs, CORS origins, and homepage URL
   - run `doctor`
 - The WorkOS CLI does not currently expose `user create`, so user provisioning should use the API or SDK directly.
+- Convex AuthKit can provision WorkOS environments and write `WORKOS_*` values into Convex env, but this behavior depends on deployment type and credentials:
+  - Dev and simple lower-env flows can auto-provision.
+  - Preview auto-provisioning can create WorkOS environment sprawl.
+  - Production deploys using deployment-specific Convex deploy keys may need a pre-existing Convex WorkOS integration before `convex deploy` can configure AuthKit.
 
 Canonical sources:
 
@@ -23,6 +27,7 @@ Canonical sources:
 - https://workos.com/docs/reference/authkit/authentication
 - https://workos.com/docs/authkit/cli-installer
 - https://workos.com/docs/sso/redirect-uris
+- https://docs.convex.dev/auth/authkit/auto-provision
 
 ## Lower-Env Rules
 
@@ -38,48 +43,58 @@ Canonical sources:
 - WorkOS client ID for the app
 - App origin, for example:
   - `http://localhost:3001`
-  - `https://studio.prismantix.com`
+  - `https://app.example.com`
 - If sealed-session login is desired:
   - `WORKOS_COOKIE_PASSWORD`
 - If org-scoped access is required:
   - WorkOS organization ID
   - optional role slug or role slugs
 
-For Prismantix, derive `APP_ORIGIN` from the Cloudflare Worker deployment origin or custom domain. Do not assume some other hosting platform will supply the right origin automatically.
-For deploys, Prismantix already routes these values through Convex `authKit` config in `convex.json`:
+Derive `APP_ORIGIN` from the actual app URL the browser uses. For Cloudflare Workers this can be either a workers.dev preview URL or a custom domain. Do not assume some other hosting platform will supply the right origin automatically.
 
-- `preview.configure.redirectUris = ["${buildEnv.STUDIO_APP_ORIGIN}/callback"]`
-- `preview.configure.appHomepageUrl = "${buildEnv.STUDIO_APP_HOMEPAGE_URL}"`
-- `preview.configure.corsOrigins = ["${buildEnv.STUDIO_APP_ORIGIN}"]`
-- `prod.configure.redirectUris = ["${buildEnv.STUDIO_APP_ORIGIN}/callback"]`
-- `prod.configure.appHomepageUrl = "${buildEnv.STUDIO_APP_HOMEPAGE_URL}"`
-- `prod.configure.corsOrigins = ["${buildEnv.STUDIO_APP_ORIGIN}"]`
+For Convex-backed deploys, inspect the repo before choosing a source of truth:
 
-That means the normal source of truth for remote redirect/CORS/homepage linkage is Convex plus the build env passed by the Cloudflare deploy workflow, not an ad hoc WorkOS dashboard edit.
+- `packages/backend/convex.json`
+- app deploy handoff scripts, for example `apps/app/scripts/deploy-from-convex.mjs`
+- CI deploy workflows, for example `.depot/workflows/deploy.yml`
+- `convex/auth.config.ts`, because Convex JWT validation usually reads `WORKOS_CLIENT_ID`
+
+The intended source of truth should be explicit. In some repos, Convex `authKit` automation owns redirect/CORS/homepage. In others, the app deploy handoff fetches WorkOS credentials from Convex env and configures WorkOS with `workos config`.
 
 ## Step 1: Select And Configure The WorkOS Environment
 
-There are three configuration paths:
+There are four configuration paths:
 
-1. Convex `authKit` automation for the normal Prismantix dev, preview, and production flows
-2. `workos install` for greenfield or disposable setup
-3. explicit `workos config` commands for an already-integrated repo when you are working outside the Convex flow
+1. Convex `authKit` automation for dev or simple deployment-specific environments
+2. Convex Shared AuthKit Environment for sharing one WorkOS environment across preview deployments
+3. `workos install` for greenfield or disposable setup
+4. explicit `workos config` commands for an already-integrated repo when you are working outside the Convex flow
 
 ### Option A: Convex `authKit` Automation
 
-This is the default path for Prismantix.
-
 Convex documents that when `convex.json` includes an `authKit` section, the CLI configures AuthKit environments for `dev`, `preview`, and `prod` code pushes using `WORKOS_CLIENT_ID` and `WORKOS_API_KEY` from local env, the build env, or the Convex deployment. Source: https://docs.convex.dev/auth/authkit/auto-provision
 
-For this repo, that means:
+This is often a good default for local dev. Be more careful in preview and production:
 
-- local `convex dev` owns local AuthKit bootstrap and writes local env values
-- preview builds configure WorkOS from `STUDIO_APP_ORIGIN` and `STUDIO_APP_HOMEPAGE_URL`
-- prod builds configure WorkOS from the production equivalents of those same build envs
+- Preview: deployment-specific AuthKit automation can create one WorkOS environment per preview deployment. That is useful for isolation, but can become dashboard/env sprawl.
+- Production: if CI uses a deployment-specific Convex deploy key, `convex deploy` may refuse to auto-provision/configure AuthKit unless WorkOS credentials already exist in build env or the target Convex deployment.
+- Dashboard integration buttons can create/link a WorkOS environment and write `WORKOS_CLIENT_ID`, `WORKOS_API_KEY`, and often `WORKOS_ENVIRONMENT_ID` into Convex env. App session secrets such as `WORKOS_COOKIE_PASSWORD` may still need to be set separately.
 
-Use this path whenever you are validating the real app deployment behavior and do not need to override WorkOS settings by hand.
+Use this path when it matches the repo's intended deployment contract and will not create unwanted WorkOS environment sprawl.
 
-### Option B: Installer Path
+### Option B: Convex Shared AuthKit Environment
+
+Convex Shared AuthKit Environments belong to a project rather than one deployment and are a better fit when many preview deployments should share one lower-env WorkOS app.
+
+Before implementing this path, verify:
+
+- whether preview deploys automatically receive `WORKOS_CLIENT_ID` and `WORKOS_API_KEY` from the shared AuthKit environment
+- whether `convex/auth.config.ts` can read `WORKOS_CLIENT_ID` in each preview deployment after deploy
+- whether app Worker deploys can fetch the needed `WORKOS_*` values from Convex without storing them in CI secrets
+- whether per-preview `WORKOS_COOKIE_PASSWORD` should be unique or shared
+- whether old per-preview WorkOS environments need cleanup
+
+### Option C: Installer Path
 
 The official installer can derive and configure the dashboard linkage for you.
 WorkOS documents that `workos install` automatically sets redirect URIs, CORS origins, and homepage URL. In practice, the redirect URI is the main input and the homepage/CORS origin are derived from its origin.
@@ -91,19 +106,19 @@ npx workos@latest install \
   --integration tanstack-start \
   --redirect-uri "$APP_ORIGIN/callback" \
   --homepage-url "$APP_ORIGIN" \
-  --install-dir apps/studio
+  --install-dir apps/app
 ```
 
 Use this only when you actually want the installer to analyze and potentially edit the project. It is not the right default for a repo that already has WorkOS integrated.
 
-### Option C: Explicit Dashboard Config
+### Option D: Explicit Dashboard Config
 
 Use these only when you intentionally need to repair or inspect linkage outside the normal Convex dev or deploy path. They keep the same effective dashboard linkage without asking the installer to touch code:
 
 ```bash
 npx workos@latest auth login
-npx workos@latest env add prismantix-preview "$WORKOS_API_KEY" --client-id "$WORKOS_CLIENT_ID"
-npx workos@latest env switch prismantix-preview
+npx workos@latest env add app-preview "$WORKOS_API_KEY" --client-id "$WORKOS_CLIENT_ID"
+npx workos@latest env switch app-preview
 npx workos@latest config redirect add "$APP_ORIGIN/callback"
 npx workos@latest config cors add "$APP_ORIGIN"
 npx workos@latest config homepage-url set "$APP_ORIGIN"
@@ -112,7 +127,7 @@ npx workos@latest doctor --install-dir "$PWD"
 
 Notes:
 
-- In Prismantix, the desired redirect URI, homepage URL, and CORS origin should match the values already declared in `convex.json` and supplied to the Cloudflare deploy workflow.
+- The desired redirect URI, homepage URL, and CORS origin should match the values already declared in `convex.json` or supplied to the app deploy handoff.
 - Redirect URIs must exist in WorkOS before hosted auth will succeed.
 - `workos doctor` is useful to confirm the current env, dashboard settings, and callback URI without mutating anything.
 - Wildcard redirect URIs are supported, but not on public suffix domains. Use them only when the preview domain pattern actually supports it.
@@ -128,7 +143,7 @@ node .agents/skills/workos-agent-access/scripts/provision-workos-user.mjs \
   --password "$WORKOS_AGENT_PASSWORD" \
   --first-name "Codex" \
   --last-name "Preview" \
-  --external-id "agent:prismantix:preview" \
+  --external-id "agent:app:preview" \
   --organization-id "$WORKOS_ORGANIZATION_ID" \
   --role-slug "admin"
 ```
@@ -170,14 +185,14 @@ sealed_session="$(
   | jq -r '.sealedSession'
 )"
 
-agent-browser --session-name prismantix-preview open "$APP_ORIGIN"
+agent-browser --session-name app-preview open "$APP_ORIGIN"
 agent-browser cookies set wos-session "$sealed_session"
 agent-browser open "$APP_ORIGIN/prompt-lab"
 ```
 
 Notes:
 
-- Prismantix currently uses the default WorkOS cookie name, `wos-session`.
+- Many AuthKit integrations use the default WorkOS cookie name, `wos-session`; verify the app has not overridden it.
 - The helper bootstraps the official WorkOS Node SDK into `.memory/workos-agent-access/runtime/` the first time it runs, so it stays self-contained instead of depending on workspace packages.
 - This browser cookie injection path is for lower-env automation. It does not preserve `HttpOnly`, but the server only needs the cookie value to be sent back on requests.
 - If the app has overridden `WORKOS_COOKIE_NAME`, use that value instead.
@@ -188,7 +203,7 @@ Notes:
 If sealed-session login is not available or is behaving oddly, use the real login flow once and persist the session:
 
 ```bash
-agent-browser --session-name prismantix-preview open "$APP_ORIGIN/sign-in"
+agent-browser --session-name app-preview open "$APP_ORIGIN/sign-in"
 agent-browser wait --load networkidle
 agent-browser snapshot -i
 ```
@@ -198,8 +213,8 @@ Then fill the hosted WorkOS form, finish the redirect, and reuse the same `--ses
 For a one-off handoff from a human-authenticated browser:
 
 ```bash
-agent-browser --auto-connect state save ./.memory/workos-agent-access/prismantix-preview-auth.json
-agent-browser --state ./.memory/workos-agent-access/prismantix-preview-auth.json open "$APP_ORIGIN/prompt-lab"
+agent-browser --auto-connect state save ./.memory/workos-agent-access/app-preview-auth.json
+agent-browser --state ./.memory/workos-agent-access/app-preview-auth.json open "$APP_ORIGIN/prompt-lab"
 ```
 
 ## When To Prefer Which Path
@@ -220,6 +235,7 @@ agent-browser --state ./.memory/workos-agent-access/prismantix-preview-auth.json
 - Protected backend requests succeed.
 - The session persists across a page refresh.
 - If org-scoped behavior matters, the correct org is selected after login.
+- If social sign-in is enabled in dev/test, click the hosted social button and confirm it reaches the provider page. Do not remove/hide social buttons as a workaround for a broken lower-env WorkOS configuration.
 
 ## Sharp Edges
 
@@ -227,4 +243,5 @@ agent-browser --state ./.memory/workos-agent-access/prismantix-preview-auth.json
 - Some email domains can be forced into SSO by WorkOS environment policy. In this repo's current test environment, `example.com` was rejected for password auth with `sso_required`, while `example.org` worked.
 - If the app origin is wrong or missing from WorkOS redirect config, hosted sign-in will fail with redirect URI errors.
 - If the cookie password is wrong, the sealed-session path will produce a session the app cannot read.
-- If the app rotates cookie config or session handling, re-check `apps/studio/src/start.ts` before assuming the fast path still applies.
+- If the app rotates cookie config or session handling, re-check the app auth hook/startup files before assuming the fast path still applies.
+- WorkOS-hosted social buttons in dev/test are expected to work. An immediate provider error such as Google `invalid_request` usually points to the wrong WorkOS environment or incomplete provider configuration, not a reason to disable social sign-in.

--- a/.agents/skills/workos-convex-authkit/SKILL.md
+++ b/.agents/skills/workos-convex-authkit/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: workos-convex-authkit
+description: Implement and debug WorkOS AuthKit + Convex (customJwt) auth in a SvelteKit, Next.js, or React app. Use for issues like preview redirect-uri-invalid, hosted social provider errors, protected route redirect failures, token refresh loops, Convex auth rejecting WorkOS JWTs (issuer/JWKS/aud mismatches), production deploy-key AuthKit failures, preview WorkOS environment sprawl, or accidental sign-outs from prefetch/GET sign-out routes.
+---
+
+# WorkOS AuthKit + Convex Playbook
+
+## Canonical Doc
+
+Primary reference: `references/playbook.md`.
+
+If you are working inside a repo with a mirrored human doc, prefer keeping that doc aligned after changing this skill.
+
+## Workflow (Fast Triage)
+
+1. Repro in the browser.
+   - Prefer lower envs (dev/preview) with real AuthKit accounts instead of any auth bypass.
+   - If social sign-in is enabled, verify the hosted social button reaches the provider page before changing UI.
+2. Use the repo's auth-debug page if one exists.
+   - Goal: disambiguate WorkOS session vs WorkOS token vs Convex token acceptance.
+3. Inspect the deployment contract.
+   - `convex.json`
+   - `convex/auth.config.ts`
+   - app auth hooks/routes
+   - deploy handoff scripts
+   - CI workflow
+4. Map the symptom to the known failure modes below.
+5. Validate with real CLI/browser signals before calling it fixed:
+   - Convex env/list/run/logs
+   - deployed app route responses
+   - hosted AuthKit URL and client id
+   - relevant CI/deploy logs
+
+## Decision Tree
+
+- If WorkOS `user` is `null`:
+  - Check route protection/redirects and that `/callback` exactly matches the configured redirect URI.
+  - Confirm `WORKOS_COOKIE_PASSWORD` is set and sufficiently long.
+- If WorkOS `user` exists but token hook errors / token loading flaps:
+  - Inspect the auth-debug token hook `error`.
+  - Check runtime logs for WorkOS refresh errors (429 / `invalid_grant`).
+  - Audit the Convex auth bridge: do not force refresh in a retry loop; prefer cached/normal `getAccessToken()` behavior.
+- If WorkOS token fetch succeeds but Convex is `authenticated: false`:
+  - Decode JWT claims (Auth Debug page shows them).
+  - Verify `iss` and `aud` align with `convex/auth.config.ts`.
+  - Confirm `WORKOS_CLIENT_ID` is set for the Convex deployment env (JWKS URL depends on it).
+- If preview login fails with `redirect-uri-invalid`:
+  - WorkOS redirect URIs are exact-match.
+  - Ensure preview config uses the actual app URL the browser hits, not a guessed alias.
+- If hosted social sign-in fails with provider `invalid_request`:
+  - Do not hide social buttons in dev/test as a fix.
+  - Verify the deployed app is using the intended WorkOS client id.
+  - Check whether a per-preview auto-provisioned WorkOS environment lacks provider configuration or differs from the shared/staging environment.
+- If users are “randomly” logged out:
+  - Look for background `GET /sign-out` in HAR/network.
+  - Prefer POST-only sign-out.
+  - For WorkOS logout, preserve session-clearing headers and redirect through the WorkOS logout URL with an app `return_to`.
+- If production deploy fails before app/API deploy:
+  - Inspect merge commit check-runs, not only the PR rollup.
+  - Deployment-specific Convex deploy keys can fail Convex `authKit.prod.configure` unless WorkOS credentials already exist in build env or target Convex env.
+  - If Convex is the WorkOS source of truth, the dashboard integration may be needed once to populate prod Convex env, and `WORKOS_COOKIE_PASSWORD` may still need to be set separately.
+- If preview deploys create many WorkOS environments:
+  - Distinguish deployment-specific Convex AuthKit envs from a Convex Shared AuthKit Environment.
+  - Evaluate a shared preview AuthKit environment before large preview volume.
+
+## Commands (Copy/Paste)
+
+```bash
+# Local Convex
+cd packages/backend
+bun run dev:setup
+
+# Prod env/debugging
+npx convex env list --prod
+npx convex logs --prod --tail
+
+# Confirm merge commit check-runs after a PR merges
+gh api repos/OWNER/REPO/commits/main/check-runs \
+  --jq '.check_runs[] | {name,status,conclusion,details_url,started_at,completed_at}'
+```
+
+## Test Accounts (Lower Envs)
+
+- Preferred: create AuthKit email+password users in dev/preview using throwaway inboxes.
+- Use `tmp/authkit_test_accounts.json` (gitignored) as the repeatable source for the current machine’s test credentials.
+- For inboxing, use Maildrop or plus-addressing (see `docs/workos-convex-authkit-playbook.md`).

--- a/.agents/skills/workos-convex-authkit/agents/openai.yaml
+++ b/.agents/skills/workos-convex-authkit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "workos + convex authkit playbook"
+  short_description: "Debug WorkOS AuthKit + Convex auth flows"
+  default_prompt: "Use $workos-convex-authkit to debug a WorkOS AuthKit + Convex (customJwt) login issue end-to-end."

--- a/.agents/skills/workos-convex-authkit/references/playbook.md
+++ b/.agents/skills/workos-convex-authkit/references/playbook.md
@@ -1,0 +1,204 @@
+# WorkOS AuthKit + Convex Custom JWT Playbook
+
+This is the debugging and implementation runbook for WorkOS AuthKit apps backed by Convex `customJwt` auth. It is framework-neutral by default and calls out SvelteKit, Next.js, Cloudflare, Depot, and Convex-specific edges where they matter.
+
+## Architecture Checklist
+
+Confirm the actual repo shape before acting:
+
+- App auth runtime:
+  - SvelteKit: `src/hooks.server.ts`, `src/routes/sign-in`, `src/routes/callback`, `src/routes/sign-out`
+  - Next.js: `proxy.ts` or `middleware.ts`, `app/callback/route.ts`, `app/sign-out/route.ts`
+  - React SPA: token bridge/provider components and backend callback/session routes
+- Convex auth:
+  - `convex/auth.config.ts` usually reads `WORKOS_CLIENT_ID`
+  - WorkOS JWT issuer/JWKS/audience must match the app's WorkOS client id
+- Deployment:
+  - `convex.json` `authKit` section
+  - app deploy handoff scripts that fetch `WORKOS_*`
+  - CI workflow and deploy keys
+
+## Convex AuthKit Environment Types
+
+Do not blur these together:
+
+- Deployment-specific Convex AuthKit environment: belongs to one Convex deployment. Good isolation, but PR previews can create many WorkOS envs.
+- Convex Shared AuthKit Environment: belongs to a Convex project and can be shared across preview deployments. Better for avoiding WorkOS env sprawl, but verify how preview deployment env vars are populated before relying on it.
+- WorkOS CLI environment: local operator config used by `workos env switch` / `workos config`. This is not automatically a Convex Shared AuthKit Environment.
+
+## Deployment Rules Learned The Hard Way
+
+- Convex remains the preferred source of truth for WorkOS env values when the repo says so. Do not copy `WORKOS_CLIENT_ID` or `WORKOS_API_KEY` into CI secrets unless the repo explicitly chooses that tradeoff.
+- Convex `authKit` automation can auto-provision in dev and some lower-env flows.
+- Production deploys using deployment-specific Convex deploy keys can fail before app/API deploy with:
+
+  ```text
+  AuthKit configuration in convex.json requires WorkOS credentials.
+  When using a deployment-specific key, you cannot automatically provision WorkOS environments.
+  ```
+
+- The Convex dashboard WorkOS integration button can create/link a WorkOS environment and write `WORKOS_CLIENT_ID`, `WORKOS_API_KEY`, and `WORKOS_ENVIRONMENT_ID` into Convex env. It may not set app-specific session secrets such as `WORKOS_COOKIE_PASSWORD`.
+- If `convex.json` keeps `authKit.prod.configure`, prod deploy may still require those WorkOS credentials to exist before `convex deploy` starts.
+- If the app deploy handoff fetches WorkOS credentials from Convex, verify the target deployment has all required values:
+
+  ```bash
+  cd packages/backend
+  npx convex env list --prod
+  npx convex env get WORKOS_CLIENT_ID --prod
+  npx convex env get WORKOS_API_KEY --prod >/dev/null
+  npx convex env get WORKOS_COOKIE_PASSWORD --prod >/dev/null
+  ```
+
+## Preview Environment Sprawl
+
+If `convex.json` enables `authKit.preview.configure`, preview deploys may provision separate WorkOS/AuthKit environments. That can be useful for isolated test environments, but it can also create 100+ WorkOS envs over time.
+
+Before switching to shared previews:
+
+1. Create or inspect a Convex Shared AuthKit Environment.
+2. Run a disposable preview deploy.
+3. Verify whether Convex writes `WORKOS_CLIENT_ID` and `WORKOS_API_KEY` into the preview deployment env.
+4. Verify `convex/auth.config.ts` works in that preview.
+5. Verify the app Worker can fetch the required `WORKOS_*` values without CI secrets.
+6. Decide whether preview `WORKOS_COOKIE_PASSWORD` should be unique per preview or shared.
+7. Document cleanup for old per-preview WorkOS environments.
+
+## Local Dev
+
+Use the repo's normal setup script first. In Scryu-like repos this is usually:
+
+```bash
+bun run dev:setup
+bun run dev:app
+```
+
+Expected local app env includes:
+
+- public Convex URL (`PUBLIC_CONVEX_URL`, `NEXT_PUBLIC_CONVEX_URL`, or framework equivalent)
+- `WORKOS_CLIENT_ID`
+- `WORKOS_API_KEY`
+- `WORKOS_COOKIE_PASSWORD`
+- callback/redirect URI env if the app uses one
+
+Convex needs `WORKOS_CLIENT_ID` for `auth.config.ts`. AuthKit server helpers usually need `WORKOS_API_KEY` and `WORKOS_COOKIE_PASSWORD`.
+
+## Browser Verification
+
+Do real browser verification for auth changes:
+
+1. Unauthenticated protected route redirects to sign-in.
+2. Sign-in page loads.
+3. Hosted AuthKit page opens with the expected WorkOS client id.
+4. If social sign-in is enabled in dev/test, click the provider button and confirm it reaches the provider page. Do not hide social buttons to work around provider errors.
+5. Callback returns to the app.
+6. App home and at least one protected route load.
+7. Convex auth probe or authenticated query succeeds.
+8. Refresh persists session.
+9. POST logout clears the app session and returns to sign-in.
+
+## Failure Modes
+
+### Hosted Social Provider `invalid_request`
+
+Symptoms:
+
+- WorkOS hosted UI displays social buttons.
+- Clicking Google/Microsoft/GitHub reaches an immediate provider error, for example Google `invalid_request`.
+
+Likely causes:
+
+- The deployed app is using a different WorkOS client id than the one you expected.
+- A freshly auto-provisioned preview WorkOS environment exists but lacks provider configuration or differs from the known-good lower-env app.
+
+Fix posture:
+
+- Do not remove or hide social buttons in dev/test.
+- Verify the hosted AuthKit URL `client_id`.
+- Verify the target Convex deployment `WORKOS_CLIENT_ID`.
+- Prefer fixing WorkOS/Convex env source-of-truth drift.
+
+### Convex Rejects WorkOS JWT
+
+Check:
+
+- JWT `iss`
+- JWT `aud`
+- `convex/auth.config.ts` JWKS URL
+- target Convex deployment env `WORKOS_CLIENT_ID`
+
+Typical WorkOS providers:
+
+- shared issuer: `https://api.workos.com/` with `applicationID` set to client id
+- user management issuer: `https://api.workos.com/user_management/<client_id>`
+- JWKS: `https://api.workos.com/sso/jwks/<client_id>`
+
+### Production Deploy Fails Before App/API Deploy
+
+Check the failed job log, not just PR status. Then verify:
+
+```bash
+gh api repos/OWNER/REPO/commits/main/check-runs \
+  --jq '.check_runs[] | {name,status,conclusion,details_url,started_at,completed_at}'
+```
+
+If Convex says AuthKit config requires WorkOS credentials:
+
+- Use the Convex dashboard integration or the repo's documented provisioning path to populate prod Convex env.
+- Set `WORKOS_COOKIE_PASSWORD` if the dashboard did not.
+- Rerun deploy from a clean checkout.
+
+### Sign-Out Does Not End WorkOS Session
+
+For SvelteKit/WorkOS AuthKit:
+
+- Prefer a POST-only sign-out endpoint.
+- Preserve session-clearing headers from the AuthKit sign-out response.
+- Redirect through the WorkOS logout URL.
+- Set `return_to` back to an app route such as `/sign-in`.
+
+For Next.js:
+
+- Avoid side-effectful GET sign-out routes, or ensure no link prefetch can hit them.
+- If a GET route is unavoidable, disable prefetch on any sign-out link.
+
+### Session Loading Loops
+
+If the app has a Convex auth bridge:
+
+- Avoid retry loops that force WorkOS refresh on every Convex auth request.
+- Prefer the SDK's normal `getAccessToken()` behavior.
+- Treat token hook errors as unauthenticated so the UI can route back through sign-in.
+
+## Depot / CI Rerun Traps
+
+- `depot ci run` can upload local dirty changes as a patch. If another agent is editing the checkout, run from a clean clone/worktree.
+- Running a single job locally can still respect workflow `if:` conditions and skip the job. If you temporarily patch workflow conditions to rerun a prod stage, do it from a disposable clean clone and do not commit the patch.
+- PR check rollups can differ from merge commit check-runs. After merge, inspect the commit on `main`.
+
+## Useful Commands
+
+```bash
+# Convex env
+cd packages/backend
+npx convex env list
+npx convex env list --prod
+npx convex env get WORKOS_CLIENT_ID --prod
+
+# Convex function smoke
+npx convex run --prod authProbe:viewer '{}'
+
+# Deploy logs
+gh api repos/OWNER/REPO/commits/main/check-runs \
+  --jq '.check_runs[] | {name,status,conclusion,details_url}'
+
+# WorkOS CLI command tree, before assuming a command exists
+npx workos --help --json
+```
+
+## Operational Guardrails
+
+- Keep an auth-debug or auth-probe surface around. It separates WorkOS session, WorkOS token, and Convex JWT acceptance failures.
+- Treat redirect URI, homepage URL, and CORS origin as exact deployed URL contracts.
+- Treat social-login failures in lower envs as real config bugs.
+- Keep WorkOS keys out of CI secrets when the repo's contract says Convex is the source of truth.
+- Document whether previews use per-deployment AuthKit envs or a Convex Shared AuthKit Environment.


### PR DESCRIPTION
## Summary
- generalize WorkOS agent-access guidance beyond repo-specific paths
- back up the WorkOS Convex AuthKit skill under .agents/skills
- document Convex AuthKit deploy-key behavior, shared preview env evaluation, social sign-in expectations, and Depot rerun traps

## Verification
- git diff --cached --check
- rg -n "Prismantix|Vercel|Next\.js app|apps/web|apps/studio|tpwdAdmin|prismantix" .agents/skills/workos-agent-access .agents/skills/workos-convex-authkit || true
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anand-testcompare/scripts-prompts-config/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
