### PR TITLE
Add merged pi command and config updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Both Bash and Zsh configurations include:
 - **npm Install Report**: `universal/npm-shell-tools.sh` wraps `npm install`/`npm i`/`npm add` and reports requested vs upstream vs installed versions when policies like `min-release-age` cause silent older installs
 - **Modern CLI Tools**: eza (ls replacement), bat (cat replacement with automatic secret masking for `.env` files), ripgrep, fd
 - **Pi/OMP Configuration**: Tracked templates for `~/.pi/agent/settings.json` and `~/.omp/agent/config.yml` with Fireworks AI provider support (models: `fireworks-openai/accounts/fireworks/routers/kimi-k2p5-turbo`, `fireworks-anthropic/accounts/fireworks/routers/kimi-k2p5-turbo`). Keep `FIREWORKS_API_KEY` local-only in `~/.shell_secrets`
-- **Pi Extensions**: `universal/.pi/agent/extensions/` tracks portable global pi extensions, including `/exit` as an alias for `/quit`
+- **Pi Extensions**: `universal/.pi/agent/extensions/` tracks portable global pi extensions, including `/exit` as an alias for `/quit` and `/merged` for post-merge verification follow-up
 
 ### Zsh-Specific Enhancements
 
@@ -127,7 +127,8 @@ PK:    ├── pi-google-code-assist-antigravity-troubleshooting.md
 JK:    ├── .pi/agent/
 QV:    │   ├── settings.json.template    # Pi agent configuration template
 EX:    │   └── extensions/
-AL:    │       └── exit-command.ts       # Adds /exit alias for quitting pi
+AL:    │       ├── exit-command.ts       # Adds /exit alias for quitting pi
+AL:    │       └── merged.ts             # Adds /merged post-merge follow-up prompt
 RM:    ├── .omp/agent/
 HQ:    │   └── config.yml.template         # OMP agent configuration template
 RT:    └── git-hooks/

--- a/osx/README.md
+++ b/osx/README.md
@@ -402,16 +402,22 @@ Important:
 
 ---
 
-## 8. Zed keybindings (global dock toggles)
+## 8. Zed config/keybindings
 
-Backed up keymap lives at:
+Backed up Zed config lives at:
+- `osx/config/zed/settings.json`
 - `osx/config/zed/keymap.json`
 
 Copy to your local machine:
 ```bash
 mkdir -p ~/.config/zed
+cp osx/config/zed/settings.json ~/.config/zed/settings.json
 cp osx/config/zed/keymap.json ~/.config/zed/keymap.json
 ```
+
+Current visual defaults:
+- theme: `One Dark`
+- icon theme: `Material Icon Theme`
 
 Keybindings included:
 - `Ctrl+B` toggle left dock

--- a/osx/config/zed/settings.json
+++ b/osx/config/zed/settings.json
@@ -1,0 +1,102 @@
+// Zed settings
+//
+// For information on how to configure Zed, see the Zed
+// documentation: https://zed.dev/docs/configuring-zed
+//
+// To see all of Zed's default settings without changing your
+// custom settings, run `zed: open default settings` from the
+// command palette (cmd-shift-p / ctrl-shift-p)
+{
+  "cli_default_open_behavior": "existing_window",
+  "project_panel": {
+    "dock": "left"
+  },
+  "outline_panel": {
+    "dock": "right"
+  },
+  "collaboration_panel": {
+    "dock": "right"
+  },
+  "git_panel": {
+    "dock": "left"
+  },
+  "colorize_brackets": true,
+  "indent_guides": {
+    "coloring": "fixed"
+  },
+  "icon_theme": "Material Icon Theme",
+  "agent_servers": {
+    "pi-acp": {
+      "type": "registry"
+    },
+    "claude-acp": {
+      "type": "registry",
+      "default_mode": "bypassPermissions"
+    },
+    "opencode": {
+      "type": "registry"
+    }
+  },
+  "agent": {
+    "sidebar_side": "right",
+    "dock": "right",
+    "default_profile": "write",
+    "profiles": {
+      "yolo": {
+        "default_model": {
+          "provider": "zed.dev",
+          "model": "gpt-5.4",
+          "enable_thinking": true,
+          "effort": "medium"
+        },
+        "name": "yolo",
+        "tools": {
+          "spawn_agent": true,
+          "fetch": true,
+          "edit_file": true,
+          "diagnostics": true,
+          "create_directory": true,
+          "copy_path": true,
+          "find_path": true,
+          "grep": true,
+          "list_directory": true,
+          "move_path": true,
+          "open": true,
+          "now": true,
+          "read_file": true,
+          "restore_file_from_disk": true,
+          "save_file": true,
+          "terminal": true,
+          "web_search": true
+        },
+        "enable_all_context_servers": false,
+        "context_servers": {}
+      }
+    },
+    "tool_permissions": {
+      "tools": {
+        "web_search": {
+          "default": "allow"
+        },
+        "fetch": {
+          "always_allow": [
+            {
+              "pattern": "^https?://developers\\.openai\\.com"
+            }
+          ]
+        }
+      }
+    },
+    "default_model": {
+      "provider": "zed.dev",
+      "model": "gpt-5.4",
+      "enable_thinking": true,
+      "effort": "medium"
+    },
+    "favorite_models": [],
+    "model_parameters": []
+  },
+  "ui_font_size": 16,
+  "buffer_font_size": 15,
+  "theme": "One Dark"
+}

--- a/universal/.pi/agent/extensions/merged.ts
+++ b/universal/.pi/agent/extensions/merged.ts
@@ -1,0 +1,20 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+const MERGED_PROMPT = `Switch to main, pull the latest changes, and do a lightweight post-merge check. Verify any production actions, including a smoke test if there is a relevant deployed app or service; otherwise note why it does not apply. Then suggest one sensible next feature or improvement.`;
+
+export default function mergedCommand(pi: ExtensionAPI) {
+	pi.registerCommand("merged", {
+		description: "Post-merge main pull, prod verification, and next feature prompt",
+		handler: async (args, ctx) => {
+			const notes = args.trim();
+			const prompt = notes ? `${MERGED_PROMPT}\n\nNotes: ${notes}` : MERGED_PROMPT;
+
+			if (ctx.isIdle()) {
+				pi.sendUserMessage(prompt);
+			} else {
+				pi.sendUserMessage(prompt, { deliverAs: "followUp" });
+				ctx.ui.notify("Queued /merged follow-up", "info");
+			}
+		},
+	});
+}

--- a/universal/global-claude.md
+++ b/universal/global-claude.md
@@ -1,10 +1,8 @@
 - Do not assume or guess facts, APIs, configs, or behavior you are not certain about. When unsure, research first (read the code, check docs, search) before answering. If you cannot verify something, say so explicitly rather than presenting a guess as fact.
 
-- Before marking any task as done, re-read the user's original request and verify every criterion was actually met. Do not stop at "good enough" — check each specific ask against what was delivered. If something was missed or only partially addressed, fix it before declaring completion.
+- Before marking any task as done, re-read the user's original request and verify every criterion was actually met and tested. Do not stop at "good enough" or "change made, it probably works" — check each specific ask against what was delivered. If something was missed or only partially addressed, fix it before declaring completion.
 
 - we should never resort to a dummy/mocked result in the event of some type of failure. masking errors is counter productive and its critical we instead gracefully catch the errors and expose them so they can be fixed, but never just introduce a fallback to a fake dataset because a real result failed.
-
-- Railway monorepo deployment: Leave Root Directory empty and set Dockerfile path to the full path from repo root (e.g., `apps/my-app/Dockerfile`). The Dockerfile should reference files relative to the repo root (e.g., `COPY apps/my-app/package.json ./`). Do NOT set both Root Directory and Dockerfile path as they stack and cause "not found" errors.
 
 - **AI SDK (v6 or @beta)**: Use `ai` or `ai@beta` package only. Do NOT add provider-specific SDKs (`@ai-sdk/openai`, `@ai-sdk/google`, `openai`, `anthropic`, etc. unless specifically requested). However if openrouter is being used `@openrouter/ai-sdk-provider` is acceptable. Pass model strings directly (e.g., `"google/gemini-3.1-flash-lite-preview"`). Env var: `AI_GATEWAY_API_KEY` if using vercel gateway or `OPENROUTER_API_KEY` if using the openrouter provider.
 


### PR DESCRIPTION
## Summary
- add a portable pi `/merged` command that queues a post-merge verification prompt
- document the new pi extension in the repository README
- include pending Zed settings and global prompt/config updates

## Testing
- `pi --offline --no-extensions -e universal/.pi/agent/extensions/merged.ts --list-models`