### PR TITLE
Make workspace 1 tiled and float other workspaces

### DIFF
--- a/osx/config/.aerospace.toml
+++ b/osx/config/.aerospace.toml
@@ -38,17 +38,54 @@ persistent-workspaces = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     outer.right = 0
 
 [[on-window-detected]]
-    # Keep common app windows responsive in tiling mode when they are created.
-    # This helps avoid a "nothing happens until I click" state after opening/closing
-    # terminals or browsers from app shortcuts.
-    if.app-name-regex-substring = 'Ghostty|Google Chrome|Zed|Cursor|Windsurf|Antigravity'
+    # Utility/overlay apps should never consume tile space on workspace 1.
+    # Keep them on the floating workspaces instead.
+    if.app-name-regex-substring = 'Wispr Flow|Helium|ChatGPT'
+    run = ['layout floating', 'move-node-to-workspace 2']
+
+[[on-window-detected]]
+    # Workspace 1 is the dedicated tiling workspace.
+    if.workspace = '1'
     run = 'layout tiling'
+
+[[on-window-detected]]
+    # Workspaces 2+ are floating workspaces.
+    if.workspace = '2'
+    run = 'layout floating'
+
+[[on-window-detected]]
+    if.workspace = '3'
+    run = 'layout floating'
+
+[[on-window-detected]]
+    if.workspace = '4'
+    run = 'layout floating'
+
+[[on-window-detected]]
+    if.workspace = '5'
+    run = 'layout floating'
+
+[[on-window-detected]]
+    if.workspace = '6'
+    run = 'layout floating'
+
+[[on-window-detected]]
+    if.workspace = '7'
+    run = 'layout floating'
+
+[[on-window-detected]]
+    if.workspace = '8'
+    run = 'layout floating'
+
+[[on-window-detected]]
+    if.workspace = '9'
+    run = 'layout floating'
 
 [mode.main.binding]
     # Layout toggles (defaults)
     alt-slash = 'layout tiles horizontal vertical'
-    # Keep alt-comma on tiles too to avoid accidental accordion mode.
-    alt-comma = 'layout tiles horizontal vertical'
+    # Alt+Comma / Alt+Period are used by terminal apps (e.g. Codex) for history/navigation.
+    # Do not bind them in AeroSpace; otherwise macOS intercepts them before Ghostty/Codex.
 
     # Focus (defaults)
     alt-h = 'focus left'
@@ -87,8 +124,8 @@ persistent-workspaces = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     # Maximize the focused window without creating a separate macOS fullscreen Space.
     cmd-ctrl-f = 'fullscreen --no-outer-gaps'
 
-    # Reuse Ghostty instead of forcing another app instance.
-    alt-enter = 'exec-and-forget open -a /Applications/Ghostty.app'
+    # Disabled: Alt+Enter is used by spreadsheet apps (e.g. Excel) to insert a newline in a cell.
+    # alt-enter = 'exec-and-forget open -na /Applications/Ghostty.app'
 
     # Workspaces (Omarchy-style on macOS)
     cmd-1 = 'workspace 1'
@@ -114,10 +151,7 @@ persistent-workspaces = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     cmd-shift-9 = 'move-node-to-workspace --focus-follows-window 9'
 
     # Backup bindings (in case cmd+1..9 is consumed by an app, e.g. browser tab switching)
-    alt-1 = 'workspace 1'
-    alt-2 = 'workspace 2'
-    alt-3 = 'workspace 3'
-    alt-4 = 'workspace 4'
+    # alt-1..4 intentionally left unbound so Option+1..4 are free for apps/macOS text input.
     alt-5 = 'workspace 5'
     alt-6 = 'workspace 6'
     alt-7 = 'workspace 7'

--- a/osx/config/.config/ghostty/config
+++ b/osx/config/.config/ghostty/config
@@ -7,12 +7,22 @@ font-size = 14
 # Theme
 theme = "Catppuccin Frappe"
 
+# Avoid macOS-native tab window state with tiling window managers. Ghostty's
+# native macOS tabs are reported to AeroSpace as separate windows, which can
+# leave phantom tile gaps. Cmd+T is bound to a split below for the same reason.
+macos-titlebar-style = tabs
+window-save-state = never
+
 # Performance optimizations
 auto-update = off
 notify-on-command-finish = never
 desktop-notifications = false
 # Prevent bells from requesting attention or rewriting the window title.
 bell-features = no-system,no-audio,no-attention,no-title,no-border
+
+# Treat macOS Option as terminal Alt so Option+Comma/Period reaches Codex
+# instead of becoming the Unicode characters ≤/≥.
+macos-option-as-alt = true
 
 # Mac-style keybindings
 keybind = super+a=select_all
@@ -21,7 +31,9 @@ keybind = super+v=paste_from_clipboard
 keybind = super+d=new_split:right
 keybind = super+shift+d=new_split:down
 keybind = super+w=close_surface
-keybind = super+t=new_tab
+# Use an internal split instead of a native macOS tab so AeroSpace never sees
+# Cmd+T as a new window and creates phantom tile gaps.
+keybind = super+t=new_split:right
 keybind = super+n=new_window
 keybind = super+shift+enter=new_window
 keybind = super+shift+left_bracket=previous_tab

--- a/osx/scripts/reapply_aerospace_layouts.sh
+++ b/osx/scripts/reapply_aerospace_layouts.sh
@@ -7,11 +7,30 @@ if ! command -v aerospace >/dev/null 2>&1; then
 fi
 
 # Give macOS a moment to restore login items before forcing workspaces back
-# into a tiled layout. This reduces the "stacked on top of each other after
-# reboot" failure mode when apps re-open before AeroSpace finishes settling.
+# into the workspace policy. This reduces the "stacked on top of each other
+# after reboot" failure mode when apps re-open before AeroSpace finishes
+# settling.
 sleep "${AEROSPACE_STARTUP_DELAY:-4}"
 
 focused_workspace="$(aerospace list-workspaces --focused 2>/dev/null | head -n 1 || true)"
+
+# Workspace policy:
+# - Workspace 1 is the dedicated tiling workspace.
+# - Workspaces 2+ are floating workspaces.
+# - Utility/overlay apps should not consume tile space on workspace 1.
+utility_app_regex='^(Helium|ChatGPT|Wispr Flow)$'
+
+# First, move utility/overlay apps off workspace 1 so they do not reserve
+# invisible/awkward tile space there.
+aerospace list-windows --workspace 1 --format '%{window-id}|%{app-name}' 2>/dev/null |
+  while IFS='|' read -r window_id app_name; do
+    [[ -n "$window_id" ]] || continue
+
+    if [[ "$app_name" =~ $utility_app_regex ]]; then
+      aerospace layout --window-id "$window_id" floating >/dev/null 2>&1 || true
+      aerospace move-node-to-workspace --window-id "$window_id" 2 >/dev/null 2>&1 || true
+    fi
+  done
 
 while IFS= read -r workspace; do
   [[ -n "$workspace" ]] || continue
@@ -22,11 +41,26 @@ while IFS= read -r workspace; do
   fi
 
   aerospace workspace "$workspace" >/dev/null 2>&1
-  aerospace layout tiles horizontal vertical >/dev/null 2>&1
-  aerospace flatten-workspace-tree >/dev/null 2>&1
-  aerospace balance-sizes >/dev/null 2>&1
+
+  if [[ "$workspace" == "1" ]]; then
+    aerospace list-windows --workspace 1 --format '%{window-id}|%{app-name}' 2>/dev/null |
+      while IFS='|' read -r window_id app_name; do
+        [[ -n "$window_id" ]] || continue
+        aerospace layout --window-id "$window_id" tiling >/dev/null 2>&1 || true
+      done
+
+    aerospace layout tiles horizontal vertical >/dev/null 2>&1 || true
+    aerospace flatten-workspace-tree --workspace 1 >/dev/null 2>&1 || true
+    aerospace balance-sizes >/dev/null 2>&1 || true
+  else
+    aerospace list-windows --workspace "$workspace" --format '%{window-id}' 2>/dev/null |
+      while IFS= read -r window_id; do
+        [[ -n "$window_id" ]] || continue
+        aerospace layout --window-id "$window_id" floating >/dev/null 2>&1 || true
+      done
+  fi
 done < <(aerospace list-workspaces --all 2>/dev/null)
 
 if [[ -n "$focused_workspace" ]]; then
-  aerospace workspace "$focused_workspace" >/dev/null 2>&1
+  aerospace workspace "$focused_workspace" >/dev/null 2>&1 || true
 fi


### PR DESCRIPTION
## Summary\n- Back up AeroSpace policy: workspace 1 tiles, workspaces 2-9 float\n- Move utility overlays (Wispr Flow, Helium, ChatGPT) to floating workspace 2 so they do not consume tile space on workspace 1\n- Update Ghostty macOS config to avoid native-tab phantom tiles by using Cmd+T split and disabling saved native tab state\n- Rework startup reapply script to enforce the workspace policy after login\n\n## Validation\n- Ran `bash -n osx/scripts/reapply_aerospace_layouts.sh`\n- Ran Ghostty config validation for `osx/config/.config/ghostty/config`