### PR TITLE
Fix AeroSpace launcher workspace behavior

### DIFF
--- a/osx/config/.aerospace.toml
+++ b/osx/config/.aerospace.toml
@@ -38,10 +38,23 @@ persistent-workspaces = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     outer.right = 0
 
 [[on-window-detected]]
-    # Utility/overlay apps should never consume tile space on workspace 1.
-    # Keep them on the floating workspaces instead.
-    if.app-name-regex-substring = 'Wispr Flow|Helium|ChatGPT'
+    # Wispr Flow overlay windows should never consume tile space on workspace 1.
+    # Keep them on a floating workspace instead.
+    if.app-name-regex-substring = 'Wispr Flow'
     run = ['layout floating', 'move-node-to-workspace 2']
+
+[[on-window-detected]]
+    # Dev/terminal/browser apps that should tile wherever they are opened.
+    # This restores the prior "snap immediately" behavior even on workspaces
+    # that otherwise default to floating.
+    if.app-name-regex-substring = 'Ghostty|WezTerm|Helium|Code - Insiders|Visual Studio Code|Zed|Cursor|Windsurf|Antigravity|Devin|Codex'
+    run = 'layout tiling'
+
+[[on-window-detected]]
+    # Chrome belongs on workspace 1 and should tile there. Helium is launched
+    # by skhd onto the current workspace instead.
+    if.app-name-regex-substring = 'Google Chrome'
+    run = ['layout tiling', 'move-node-to-workspace 1']
 
 [[on-window-detected]]
     # Workspace 1 is the dedicated tiling workspace.

--- a/osx/config/.skhdrc
+++ b/osx/config/.skhdrc
@@ -8,10 +8,10 @@ cmd + shift - t [
   "Helium" ~
   * : open -a /Applications/Ghostty.app
 ]
-cmd + shift - return : osascript -e 'tell application "Ghostty" to activate' -e 'tell application "Ghostty" to new window'
-cmd + shift - b : open -na /Applications/Helium.app
-cmd + shift - f : open -a Finder
-cmd + shift - a : open -a ChatGPT
+cmd + shift - return : $HOME/scripts-prompts-config/osx/scripts/open_app_on_current_workspace.sh Ghostty open -na /Applications/Ghostty.app
+cmd + shift - b : $HOME/scripts-prompts-config/osx/scripts/open_app_on_current_workspace.sh Helium open -na /Applications/Helium.app
+cmd + shift - f : $HOME/scripts-prompts-config/osx/scripts/open_app_on_current_workspace.sh Finder open -a Finder
+cmd + shift - a : $HOME/scripts-prompts-config/osx/scripts/open_app_on_current_workspace.sh ChatGPT open -a ChatGPT
 
 # Optional "always fresh instance" style:
 # cmd - return : open -na /Applications/Ghostty.app

--- a/osx/scripts/open_app_on_current_workspace.sh
+++ b/osx/scripts/open_app_on_current_workspace.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <AeroSpace app name> <command> [args...]" >&2
+  exit 64
+fi
+
+app_name="$1"
+shift
+
+if ! command -v aerospace >/dev/null 2>&1; then
+  exec "$@"
+fi
+
+target_workspace="$(aerospace list-workspaces --focused 2>/dev/null | head -n 1 || true)"
+
+before_ids="$(mktemp)"
+after_ids="$(mktemp)"
+trap 'rm -f "$before_ids" "$after_ids"' EXIT
+
+aerospace list-windows --all --format '%{window-id}|%{app-name}' 2>/dev/null |
+  awk -F'|' -v app="$app_name" '$2 == app { print $1 }' >"$before_ids" || true
+
+"$@" >/dev/null 2>&1 &
+
+new_window_id=""
+for _ in {1..40}; do
+  sleep 0.10
+
+  aerospace list-windows --all --format '%{window-id}|%{app-name}' 2>/dev/null |
+    awk -F'|' -v app="$app_name" '$2 == app { print $1 }' >"$after_ids" || true
+
+  new_window_id="$(comm -13 <(sort "$before_ids") <(sort "$after_ids") | tail -n 1 || true)"
+  if [[ -n "$new_window_id" ]]; then
+    break
+  fi
+done
+
+# Some apps reuse an existing window or are slow to report the new one. Fall
+# back to the focused window if it belongs to the launched app.
+if [[ -z "$new_window_id" ]]; then
+  focused_line="$(aerospace list-windows --focused --format '%{window-id}|%{app-name}' 2>/dev/null || true)"
+  focused_app="${focused_line#*|}"
+  if [[ "$focused_app" == "$app_name" ]]; then
+    new_window_id="${focused_line%%|*}"
+  fi
+fi
+
+if [[ -n "$new_window_id" && -n "$target_workspace" ]]; then
+  aerospace move-node-to-workspace --window-id "$new_window_id" "$target_workspace" >/dev/null 2>&1 || true
+
+  # Workspace 1 is tiled. Terminals/dev launchers should also tile wherever
+  # they are opened so a terminal on a blank floating workspace fills it.
+  case "$app_name" in
+    Ghostty|WezTerm|Helium|Codex|Devin|"Code - Insiders"|"Visual Studio Code"|Zed|Cursor|Windsurf|Antigravity)
+      aerospace layout --window-id "$new_window_id" tiling >/dev/null 2>&1 || true
+      ;;
+    *)
+      if [[ "$target_workspace" == "1" ]]; then
+        aerospace layout --window-id "$new_window_id" tiling >/dev/null 2>&1 || true
+      else
+        aerospace layout --window-id "$new_window_id" floating >/dev/null 2>&1 || true
+      fi
+      ;;
+  esac
+
+  aerospace workspace "$target_workspace" >/dev/null 2>&1 || true
+fi

--- a/osx/scripts/reapply_aerospace_layouts.sh
+++ b/osx/scripts/reapply_aerospace_layouts.sh
@@ -17,10 +17,12 @@ focused_workspace="$(aerospace list-workspaces --focused 2>/dev/null | head -n 1
 # Workspace policy:
 # - Workspace 1 is the dedicated tiling workspace.
 # - Workspaces 2+ are floating workspaces.
-# - Utility/overlay apps should not consume tile space on workspace 1.
-utility_app_regex='^(Helium|ChatGPT|Wispr Flow)$'
+# - Wispr Flow overlay windows should not consume tile space on workspace 1.
+utility_app_regex='^(Wispr Flow)$'
+dev_tile_app_regex='^(Ghostty|WezTerm|Helium|Code - Insiders|Visual Studio Code|Zed|Cursor|Windsurf|Antigravity|Devin|Codex)$'
+workspace_1_app_regex='^(Google Chrome)$'
 
-# First, move utility/overlay apps off workspace 1 so they do not reserve
+# First, move Wispr Flow overlay windows off workspace 1 so they do not reserve
 # invisible/awkward tile space there.
 aerospace list-windows --workspace 1 --format '%{window-id}|%{app-name}' 2>/dev/null |
   while IFS='|' read -r window_id app_name; do
@@ -31,6 +33,34 @@ aerospace list-windows --workspace 1 --format '%{window-id}|%{app-name}' 2>/dev/
       aerospace move-node-to-workspace --window-id "$window_id" 2 >/dev/null 2>&1 || true
     fi
   done
+
+# Dev/terminal/browser apps should tile wherever they are. On a blank workspace
+# this makes terminals immediately fill the workspace, and it restores snapping
+# for Ghostty/editors/Helium on floating-default workspaces.
+for workspace in $(aerospace list-workspaces --all 2>/dev/null); do
+  aerospace list-windows --workspace "$workspace" --format '%{window-id}|%{app-name}' 2>/dev/null |
+    while IFS='|' read -r window_id app_name; do
+      [[ -n "$window_id" ]] || continue
+
+      if [[ "$app_name" =~ $dev_tile_app_regex ]]; then
+        aerospace layout --window-id "$window_id" tiling >/dev/null 2>&1 || true
+      fi
+    done
+done
+
+# Chrome belongs on workspace 1 and should be tiled there, not left
+# overlapping on floating workspaces after login/session restore.
+for workspace in $(aerospace list-workspaces --all 2>/dev/null); do
+  aerospace list-windows --workspace "$workspace" --format '%{window-id}|%{app-name}' 2>/dev/null |
+    while IFS='|' read -r window_id app_name; do
+      [[ -n "$window_id" ]] || continue
+
+      if [[ "$app_name" =~ $workspace_1_app_regex ]]; then
+        aerospace move-node-to-workspace --window-id "$window_id" 1 >/dev/null 2>&1 || true
+        aerospace layout --window-id "$window_id" tiling >/dev/null 2>&1 || true
+      fi
+    done
+done
 
 while IFS= read -r workspace; do
   [[ -n "$workspace" ]] || continue
@@ -53,10 +83,14 @@ while IFS= read -r workspace; do
     aerospace flatten-workspace-tree --workspace 1 >/dev/null 2>&1 || true
     aerospace balance-sizes >/dev/null 2>&1 || true
   else
-    aerospace list-windows --workspace "$workspace" --format '%{window-id}' 2>/dev/null |
-      while IFS= read -r window_id; do
+    aerospace list-windows --workspace "$workspace" --format '%{window-id}|%{app-name}' 2>/dev/null |
+      while IFS='|' read -r window_id app_name; do
         [[ -n "$window_id" ]] || continue
-        aerospace layout --window-id "$window_id" floating >/dev/null 2>&1 || true
+        if [[ "$app_name" =~ $dev_tile_app_regex ]]; then
+          aerospace layout --window-id "$window_id" tiling >/dev/null 2>&1 || true
+        else
+          aerospace layout --window-id "$window_id" floating >/dev/null 2>&1 || true
+        fi
       done
   fi
 done < <(aerospace list-workspaces --all 2>/dev/null)


### PR DESCRIPTION
## Summary\n- Add a launcher wrapper that opens app shortcuts on the currently focused AeroSpace workspace\n- Update skhd app launchers to use the wrapper for Ghostty, Helium, Finder, and ChatGPT\n- Narrow overlay handling to Wispr Flow only\n- Keep dev/terminal/Helium windows tiled wherever opened while leaving other non-workspace-1 apps floating\n- Keep Chrome assigned to workspace 1/tiled\n\n## Validation\n- Ran `bash -n osx/scripts/reapply_aerospace_layouts.sh`\n- Ran `bash -n osx/scripts/open_app_on_current_workspace.sh`\n- Ran `git diff --check` on changed files