### PR TITLE
chore: clean agent config defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,6 @@ YT:**/.pi/agent/settings.json
 SH:**/.pi/agent/auth.json
 ZJ:**/.omp/agent/config.yml
 NS:**/.omp/agent/auth.json
-RR:**/.claude-omc/settings.json
-BK:**/.claude-omc/state.json
 
 # local agent/runtime artifacts
 .memory/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ cp osx/config/.aerospace.toml ~/.aerospace.toml
 cp osx/config/.skhdrc ~/.skhdrc
 mkdir -p ~/.claude
 cp osx/config/.claude/settings.json ~/.claude/settings.json
+cp osx/config/.claude/keybindings.json ~/.claude/keybindings.json
 mkdir -p ~/.config/ghostty
 cp osx/config/.config/ghostty/config ~/.config/ghostty/config
 mkdir -p ~/.config/wezterm
@@ -52,7 +53,7 @@ Both Bash and Zsh configurations include:
 - **System Info**: Memory (`meminfo`), CPU (`cpuinfo`), disk usage (`diskinfo`)
 - **Clipboard**: Cross-platform clipboard support (`pbcopy`, `pbpaste` via xclip)
 - **Secure Credentials**: Automatic loading from `.shell_secrets`
-- **Claude Code**: Tracked macOS user settings disable commit/PR attribution, point the Claude status line at `universal/claude-statusline.sh`, and persist `effortLevel: "high"`; `CLAUDE_CODE_EFFORT_LEVEL=max` in shell config overrides that to max on supported models
+- **Claude Code**: Tracked macOS user settings disable commit/PR attribution, point the Claude status line at `universal/claude-statusline.sh`, persist `effortLevel: "high"` as a fallback, add Option+. / Option+, effort keybindings in the model picker, and leave `CLAUDE_CODE_EFFORT_LEVEL` unset so `/effort` or ultracode can choose the active effort
 - **Exa MCP**: Tracked Codex/OpenCode configs use Exa's hosted MCP endpoint and enable `web_search_exa`, `web_search_advanced_exa`, `get_code_context_exa`, and `crawling_exa`. Keep any `EXA_API_KEY` usage local-only; do not commit it into repo-managed MCP URLs. Tracked OpenCode config lives under `universal/.config/opencode/`, including `opencode.jsonc` and `tui.jsonc`.
 - **Codex Feature Banner**: `universal/codex-shell-tools.sh` wraps `codex` so interactive launches can compare current flags against a clean-home default baseline and highlight only the drifted values
 - **pnpm 11 Defaults**: `osx/scripts/configure_pnpm_defaults.sh` activates `pnpm@11.5.1` through Corepack and writes persistent pnpm security defaults (`minimumReleaseAge`, exotic subdependency blocking, strict dependency builds) to pnpm's user config.

--- a/linux-omarchy/.claude/settings.json
+++ b/linux-omarchy/.claude/settings.json
@@ -199,16 +199,7 @@
     "gopls-lsp@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
     "hookify@claude-plugins-official": true,
-    "oh-my-claudecode@omc": false,
     "code-review@claude-plugins-official": true
-  },
-  "extraKnownMarketplaces": {
-    "omc": {
-      "source": {
-        "source": "git",
-        "url": "https://github.com/Yeachan-Heo/oh-my-claudecode.git"
-      }
-    }
   },
   "effortLevel": "high",
   "skipDangerousModePermissionPrompt": true

--- a/linux-omarchy/configs/.gitignore_global
+++ b/linux-omarchy/configs/.gitignore_global
@@ -1,7 +1,3 @@
-# oh-my-claudecode / oh-my-codex runtime state
-.omc/
-.omx/
-
 # Agent skill sync outputs (source lives in scripts-prompts-config)
 **/.agents/skills/*
 **/.claude/skills/*

--- a/linux-omarchy/configs/.zshrc
+++ b/linux-omarchy/configs/.zshrc
@@ -141,36 +141,6 @@ fi
 # sentry
 fpath=("/home/anandpant/.local/share/zsh/site-functions" $fpath)
 
-# Claude Code – max effort on supported models (overrides effortLevel in settings.json)
-export CLAUDE_CODE_EFFORT_LEVEL=max
-
-# Launch Claude Code with oh-my-claudecode: `omc` enables OMC for the
-# session, plain `claude` runs vanilla (the default in settings.json).
-omc() {
-  local settings="$HOME/.claude/settings.json"
-  local vanilla_sl="bash $HOME/scripts-prompts-config/universal/claude-statusline.sh"
-  local omc_sl='node $HOME/.claude/hud/omc-hud.mjs'
-
-  # flip to OMC
-  local tmp=$(mktemp)
-  jq '
-    .enabledPlugins["oh-my-claudecode@omc"] = true |
-    .statusLine.command = "'"$omc_sl"'"
-  ' "$settings" > "$tmp" && mv "$tmp" "$settings"
-
-  # run claude, then restore vanilla on exit
-  claude "$@"
-  local rc=$?
-
-  tmp=$(mktemp)
-  jq '
-    .enabledPlugins["oh-my-claudecode@omc"] = false |
-    .statusLine.command = "'"$vanilla_sl"'"
-  ' "$settings" > "$tmp" && mv "$tmp" "$settings"
-
-  return $rc
-}
-
 # Turso
 export PATH="$PATH:/home/anandpant/.turso"
 

--- a/osx/README.md
+++ b/osx/README.md
@@ -59,9 +59,10 @@ fi
 ```
 
 Today that file enables:
-- `CLAUDE_CODE_EFFORT_LEVEL=max`
 - the Codex feature banner from `universal/codex-shell-tools.sh`
 - pnpm 11 environment defaults and common pnpm shortcuts (`p`, `pi`, `pa`, `pad`, `px`, `prun`)
+
+It intentionally does not export `CLAUDE_CODE_EFFORT_LEVEL`; Claude Code treats any value as an override, so leaving it absent lets `/effort` or ultracode choose the active effort.
 
 ---
 
@@ -160,19 +161,22 @@ disabled = true
 
 ## 3b. Claude Code settings
 
-Backed up Claude Code user settings live at:
+Backed up Claude Code user settings and keybindings live at:
 - `osx/config/.claude/settings.json`
+- `osx/config/.claude/keybindings.json`
 
 Copy them into place:
 ```bash
 mkdir -p ~/.claude
 cp osx/config/.claude/settings.json ~/.claude/settings.json
+cp osx/config/.claude/keybindings.json ~/.claude/keybindings.json
 ```
 
-This tracked config does two important things:
+This tracked config does these important things:
 - disables Claude Code commit and PR attribution globally with `"attribution": { "commit": "", "pr": "" }`
 - points Claude's status line at the tracked repo script
 - persists `/effort high` in `~/.claude/settings.json` as the fallback session default
+- binds Option+. / Option+, in Claude Code's model picker to increase/decrease effort
 
 ```json
 {
@@ -188,11 +192,7 @@ This tracked config does two important things:
 }
 ```
 
-If you want Claude Code to start at max effort on supported models, add this to `~/.zshrc`:
-
-```bash
-export CLAUDE_CODE_EFFORT_LEVEL=max
-```
+By default, the shell extras leave `CLAUDE_CODE_EFFORT_LEVEL` unset, because any value in that environment variable takes precedence over both `/effort` and the persisted `effortLevel` setting. Leaving the variable absent lets `/effort` or ultracode choose the active effort.
 
 The script lives at:
 - `universal/claude-statusline.sh`

--- a/osx/config/.claude/keybindings.json
+++ b/osx/config/.claude/keybindings.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-keybindings.json",
+  "$docs": "https://code.claude.com/docs/en/keybindings",
+  "bindings": [
+    {
+      "context": "ModelPicker",
+      "bindings": {
+        "alt+.": "modelPicker:increaseEffort",
+        "alt+,": "modelPicker:decreaseEffort"
+      }
+    }
+  ]
+}

--- a/osx/config/.config/git/ignore
+++ b/osx/config/.config/git/ignore
@@ -1,13 +1,5 @@
 **/.claude/settings.local.json
 
-# OMC local runtime artifacts
-**/.omc/*
-!**/.omc/skills/
-!**/.omc/skills/**
-**/.claude/skills/omc-reference/
-**/.claude/skills/omc-reference/**
-**/.claude/CLAUDE-omc.md
-
 # Agent skill sync outputs (source lives in scripts-prompts-config)
 **/.agents/skills/*
 **/.claude/skills/*

--- a/osx/config/shell-extras.zsh
+++ b/osx/config/shell-extras.zsh
@@ -1,8 +1,5 @@
 # shell-extras.zsh — Source from ~/.zshrc on macOS machines.
-# Adds Codex feature banner and Claude Code env overrides.
-
-# Claude Code: always use max effort
-export CLAUDE_CODE_EFFORT_LEVEL=max
+# Adds Codex feature banner and Claude Code shell helpers.
 
 # Codex: print all feature flags before each launch; green means the value differs from the default baseline
 export CODEX_FEATURE_MODE=all

--- a/universal/.codex/config.toml
+++ b/universal/.codex/config.toml
@@ -1,5 +1,5 @@
-model = "gpt-5.3-codex"
-model_reasoning_effort = "high"
+model = "gpt-5.5"
+model_reasoning_effort = "medium"
 suppress_unstable_features_warning = true
 web_search = "cached"
 personality = "none"
@@ -25,7 +25,7 @@ multi_agent_v2 = true
 steer = true
 personality = false
 apps = false
-plugins = false
+plugins = true
 js_repl = true
 code_mode = true
 codex_hooks = true


### PR DESCRIPTION
## Summary
- remove remaining OMC/Oh My Claude references from tracked Linux/macOS configs and ignore files
- add tracked Claude Code keybindings for model-picker effort changes
- stop exporting CLAUDE_CODE_EFFORT_LEVEL and update Codex default model/plugin settings

## Verification
- jq empty linux-omarchy/.claude/settings.json osx/config/.claude/settings.json osx/config/.claude/keybindings.json
- git diff --check
- rg --hidden for OMC/Oh My references returns no matches